### PR TITLE
Update wkhtmltoimage shlinkio/shlink#424

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 #### Fixed
 
 * [#416](https://github.com/shlinkio/shlink/issues/416) Fixed error thrown when trying to locate visits after the GeoLite2 DB is downloaded for the first time.
+* [#424](https://github.com/shlinkio/shlink/issues/424) Update wkhtmltoimage to version 0.12.5
 
 
 ## 1.17.0 - 2019-05-13


### PR DESCRIPTION
Fix for #424 

I extracted the binary from the Debian 9 amd64 .deb file.
This worked at least for me.