### PR TITLE
Date filters for short urls list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
     > After Shlink v2 is released, both API versions will behave like API v2.
 
+* [#575](https://github.com/shlinkio/shlink/issues/575) Added support to filter short URL lists by date ranges.
+
+    * The `GET /short-urls` endpoint now accepts the `startDate` and `endDate` query params.
+    * The `short-urls:list` command now allows `--startDate` and `--endDate` flags to be optionally provided.
+
 #### Changed
 
 * [#492](https://github.com/shlinkio/shlink/issues/492) Updated to monolog 2, together with other dependencies, like Symfony 5 and infection-php.

--- a/docs/swagger/paths/v1_short-urls.json
+++ b/docs/swagger/paths/v1_short-urls.json
@@ -54,6 +54,24 @@
                         "visits"
                     ]
                 }
+            },
+            {
+                "name": "startDate",
+                "in": "query",
+                "description": "The date (in ISO-8601 format) from which we want to get short URLs.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "name": "endDate",
+                "in": "query",
+                "description": "The date (in ISO-8601 format) until which we want to get short URLs.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
             }
         ],
         "security": [

--- a/module/CLI/src/Command/Api/GenerateKeyCommand.php
+++ b/module/CLI/src/Command/Api/GenerateKeyCommand.php
@@ -36,7 +36,7 @@ class GenerateKeyCommand extends Command
             ->addOption(
                 'expirationDate',
                 'e',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'The date in which the API key should expire. Use any valid PHP format.'
             );
     }

--- a/module/CLI/src/Command/ShortUrl/GetVisitsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/GetVisitsCommand.php
@@ -5,24 +5,25 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\CLI\Command\ShortUrl;
 
 use Cake\Chronos\Chronos;
+use Shlinkio\Shlink\CLI\Command\Util\AbstractWithDateRangeCommand;
 use Shlinkio\Shlink\CLI\Util\ExitCodes;
 use Shlinkio\Shlink\CLI\Util\ShlinkTable;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\Visit;
 use Shlinkio\Shlink\Core\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Service\VisitsTrackerInterface;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Zend\Stdlib\ArrayUtils;
+use Throwable;
 
-use function array_map;
+use function Functional\map;
 use function Functional\select_keys;
+use function sprintf;
 
-class GetVisitsCommand extends Command
+class GetVisitsCommand extends AbstractWithDateRangeCommand
 {
     public const NAME = 'short-url:visits';
     private const ALIASES = ['shortcode:visits', 'short-code:visits'];
@@ -36,25 +37,23 @@ class GetVisitsCommand extends Command
         parent::__construct();
     }
 
-    protected function configure(): void
+    protected function doConfigure(): void
     {
         $this
             ->setName(self::NAME)
             ->setAliases(self::ALIASES)
             ->setDescription('Returns the detailed visits information for provided short code')
-            ->addArgument('shortCode', InputArgument::REQUIRED, 'The short code which visits we want to get')
-            ->addOption(
-                'startDate',
-                's',
-                InputOption::VALUE_OPTIONAL,
-                'Allows to filter visits, returning only those older than start date'
-            )
-            ->addOption(
-                'endDate',
-                'e',
-                InputOption::VALUE_OPTIONAL,
-                'Allows to filter visits, returning only those newer than end date'
-            );
+            ->addArgument('shortCode', InputArgument::REQUIRED, 'The short code which visits we want to get');
+    }
+
+    protected function getStartDateDesc(): string
+    {
+        return 'Allows to filter visits, returning only those older than start date';
+    }
+
+    protected function getEndDateDesc(): string
+    {
+        return 'Allows to filter visits, returning only those newer than end date';
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -74,24 +73,18 @@ class GetVisitsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $shortCode = $input->getArgument('shortCode');
-        $startDate = $this->getDateOption($input, 'startDate');
-        $endDate = $this->getDateOption($input, 'endDate');
+        $startDate = $this->getDateOption($input, $output, 'startDate');
+        $endDate = $this->getDateOption($input, $output, 'endDate');
 
         $paginator = $this->visitsTracker->info($shortCode, new VisitsParams(new DateRange($startDate, $endDate)));
-        $visits = ArrayUtils::iteratorToArray($paginator->getCurrentItems());
 
-        $rows = array_map(function (Visit $visit) {
+        $rows = map($paginator->getCurrentItems(), function (Visit $visit) {
             $rowData = $visit->jsonSerialize();
             $rowData['country'] = $visit->getVisitLocation()->getCountryName();
             return select_keys($rowData, ['referer', 'date', 'userAgent', 'country']);
-        }, $visits);
+        });
         ShlinkTable::fromOutput($output)->render(['Referer', 'Date', 'User agent', 'Country'], $rows);
-        return ExitCodes::EXIT_SUCCESS;
-    }
 
-    private function getDateOption(InputInterface $input, $key)
-    {
-        $value = $input->getOption($key);
-        return ! empty($value) ? Chronos::parse($value) : $value;
+        return ExitCodes::EXIT_SUCCESS;
     }
 }

--- a/module/CLI/src/Command/ShortUrl/GetVisitsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/GetVisitsCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\CLI\Command\ShortUrl;
 
-use Cake\Chronos\Chronos;
 use Shlinkio\Shlink\CLI\Command\Util\AbstractWithDateRangeCommand;
 use Shlinkio\Shlink\CLI\Util\ExitCodes;
 use Shlinkio\Shlink\CLI\Util\ShlinkTable;
@@ -14,14 +13,11 @@ use Shlinkio\Shlink\Core\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Service\VisitsTrackerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Throwable;
 
 use function Functional\map;
 use function Functional\select_keys;
-use function sprintf;
 
 class GetVisitsCommand extends AbstractWithDateRangeCommand
 {

--- a/module/CLI/src/Command/ShortUrl/ListShortUrlsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/ListShortUrlsCommand.php
@@ -109,12 +109,12 @@ class ListShortUrlsCommand extends AbstractWithDateRangeCommand
         $showTags = (bool) $input->getOption('showTags');
         $startDate = $this->getDateOption($input, $output, 'startDate');
         $endDate = $this->getDateOption($input, $output, 'endDate');
+        $orderBy = $this->processOrderBy($input);
 
         $transformer = new ShortUrlDataTransformer($this->domainConfig);
 
         do {
             $result = $this->renderPage(
-                $input,
                 $output,
                 $page,
                 $searchTerm,
@@ -122,6 +122,7 @@ class ListShortUrlsCommand extends AbstractWithDateRangeCommand
                 $showTags,
                 $startDate,
                 $endDate,
+                $orderBy,
                 $transformer
             );
             $page++;
@@ -138,7 +139,6 @@ class ListShortUrlsCommand extends AbstractWithDateRangeCommand
     }
 
     private function renderPage(
-        InputInterface $input,
         OutputInterface $output,
         int $page,
         ?string $searchTerm,
@@ -146,13 +146,14 @@ class ListShortUrlsCommand extends AbstractWithDateRangeCommand
         bool $showTags,
         ?Chronos $startDate,
         ?Chronos $endDate,
+        $orderBy,
         DataTransformerInterface $transformer
     ): Paginator {
         $result = $this->shortUrlService->listShortUrls(
             $page,
             $searchTerm,
             $tags,
-            $this->processOrderBy($input),
+            $orderBy,
             new DateRange($startDate, $endDate)
         );
 
@@ -181,6 +182,9 @@ class ListShortUrlsCommand extends AbstractWithDateRangeCommand
         return $result;
     }
 
+    /**
+     * @return array|string|null
+     */
     private function processOrderBy(InputInterface $input)
     {
         $orderBy = $input->getOption('orderBy');

--- a/module/CLI/src/Command/Util/AbstractWithDateRangeCommand.php
+++ b/module/CLI/src/Command/Util/AbstractWithDateRangeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\CLI\Command\Util;
+
+use Cake\Chronos\Chronos;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+use function sprintf;
+
+abstract class AbstractWithDateRangeCommand extends Command
+{
+    final protected function configure(): void
+    {
+        $this->doConfigure();
+        $this
+            ->addOption('startDate', 's', InputOption::VALUE_REQUIRED, $this->getStartDateDesc())
+            ->addOption('endDate', 'e', InputOption::VALUE_REQUIRED, $this->getEndDateDesc());
+    }
+
+    protected function getDateOption(InputInterface $input, OutputInterface $output, string $key): ?Chronos
+    {
+        $value = $input->getOption($key);
+        if (empty($value)) {
+            return null;
+        }
+
+        try {
+            return Chronos::parse($value);
+        } catch (Throwable $e) {
+            $output->writeln(sprintf(
+                '<comment>> Ignored provided "%s" since its value "%s" is not a valid date. <</comment>',
+                $key,
+                $value
+            ));
+
+            if ($output->isVeryVerbose()) {
+                $this->getApplication()->renderThrowable($e, $output);
+            }
+
+            return null;
+        }
+    }
+
+    abstract protected function doConfigure(): void;
+
+    abstract protected function getStartDateDesc(): string;
+    abstract protected function getEndDateDesc(): string;
+}

--- a/module/CLI/test/Command/ShortUrl/GetVisitsCommandTest.php
+++ b/module/CLI/test/Command/ShortUrl/GetVisitsCommandTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Zend\Paginator\Adapter\ArrayAdapter;
 use Zend\Paginator\Paginator;
 
+use function sprintf;
+
 class GetVisitsCommandTest extends TestCase
 {
     /** @var CommandTester */
@@ -39,7 +41,7 @@ class GetVisitsCommandTest extends TestCase
     }
 
     /** @test */
-    public function noDateFlagsTriesToListWithoutDateRange()
+    public function noDateFlagsTriesToListWithoutDateRange(): void
     {
         $shortCode = 'abc123';
         $this->visitsTracker->info($shortCode, new VisitsParams(new DateRange(null, null)))->willReturn(
@@ -50,7 +52,7 @@ class GetVisitsCommandTest extends TestCase
     }
 
     /** @test */
-    public function providingDateFlagsTheListGetsFiltered()
+    public function providingDateFlagsTheListGetsFiltered(): void
     {
         $shortCode = 'abc123';
         $startDate = '2016-01-01';
@@ -67,6 +69,27 @@ class GetVisitsCommandTest extends TestCase
             '--startDate' => $startDate,
             '--endDate' => $endDate,
         ]);
+    }
+
+    /** @test */
+    public function providingInvalidDatesPrintsWarning(): void
+    {
+        $shortCode = 'abc123';
+        $startDate = 'foo';
+        $info = $this->visitsTracker->info($shortCode, new VisitsParams(new DateRange()))
+            ->willReturn(new Paginator(new ArrayAdapter([])));
+
+        $this->commandTester->execute([
+            'shortCode' => $shortCode,
+            '--startDate' => $startDate,
+        ]);
+        $output = $this->commandTester->getDisplay();
+
+        $info->shouldHaveBeenCalledOnce();
+        $this->assertStringContainsString(
+            sprintf('Ignored provided "startDate" since its value "%s" is not a valid date', $startDate),
+            $output
+        );
     }
 
     /** @test */

--- a/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
+++ b/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace ShlinkioTest\Shlink\CLI\Command\ShortUrl;
 
+use Cake\Chronos\Chronos;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Shlinkio\Shlink\CLI\Command\ShortUrl\ListShortUrlsCommand;
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Service\ShortUrlServiceInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Zend\Paginator\Adapter\ArrayAdapter;
 use Zend\Paginator\Paginator;
+
+use function explode;
 
 class ListShortUrlsCommandTest extends TestCase
 {
@@ -32,17 +36,7 @@ class ListShortUrlsCommandTest extends TestCase
     }
 
     /** @test */
-    public function noInputCallsListJustOnce()
-    {
-        $this->shortUrlService->listShortUrls(1, null, [], null)->willReturn(new Paginator(new ArrayAdapter()))
-                                                                ->shouldBeCalledOnce();
-
-        $this->commandTester->setInputs(['n']);
-        $this->commandTester->execute([]);
-    }
-
-    /** @test */
-    public function loadingMorePagesCallsListMoreTimes()
+    public function loadingMorePagesCallsListMoreTimes(): void
     {
         // The paginator will return more than one page
         $data = [];
@@ -64,7 +58,7 @@ class ListShortUrlsCommandTest extends TestCase
     }
 
     /** @test */
-    public function havingMorePagesButAnsweringNoCallsListJustOnce()
+    public function havingMorePagesButAnsweringNoCallsListJustOnce(): void
     {
         // The paginator will return more than one page
         $data = [];
@@ -72,8 +66,9 @@ class ListShortUrlsCommandTest extends TestCase
             $data[] = new ShortUrl('url_' . $i);
         }
 
-        $this->shortUrlService->listShortUrls(1, null, [], null)->willReturn(new Paginator(new ArrayAdapter($data)))
-                                                                ->shouldBeCalledOnce();
+        $this->shortUrlService->listShortUrls(1, null, [], null, new DateRange())
+            ->willReturn(new Paginator(new ArrayAdapter($data)))
+            ->shouldBeCalledOnce();
 
         $this->commandTester->setInputs(['n']);
         $this->commandTester->execute([]);
@@ -89,25 +84,82 @@ class ListShortUrlsCommandTest extends TestCase
     }
 
     /** @test */
-    public function passingPageWillMakeListStartOnThatPage()
+    public function passingPageWillMakeListStartOnThatPage(): void
     {
         $page = 5;
-        $this->shortUrlService->listShortUrls($page, null, [], null)->willReturn(new Paginator(new ArrayAdapter()))
-                                                                    ->shouldBeCalledOnce();
+        $this->shortUrlService->listShortUrls($page, null, [], null, new DateRange())
+            ->willReturn(new Paginator(new ArrayAdapter()))
+            ->shouldBeCalledOnce();
 
         $this->commandTester->setInputs(['y']);
         $this->commandTester->execute(['--page' => $page]);
     }
 
     /** @test */
-    public function ifTagsFlagIsProvidedTagsColumnIsIncluded()
+    public function ifTagsFlagIsProvidedTagsColumnIsIncluded(): void
     {
-        $this->shortUrlService->listShortUrls(1, null, [], null)->willReturn(new Paginator(new ArrayAdapter()))
-                                                                ->shouldBeCalledOnce();
+        $this->shortUrlService->listShortUrls(1, null, [], null, new DateRange())
+            ->willReturn(new Paginator(new ArrayAdapter()))
+            ->shouldBeCalledOnce();
 
         $this->commandTester->setInputs(['y']);
         $this->commandTester->execute(['--showTags' => true]);
         $output = $this->commandTester->getDisplay();
         $this->assertStringContainsString('Tags', $output);
+    }
+
+    /**
+     * @test
+     * @dataProvider provideArgs
+     */
+    public function serviceIsInvokedWithProvidedArgs(
+        array $commandArgs,
+        ?int $page,
+        ?string $searchTerm,
+        array $tags,
+        ?DateRange $dateRange
+    ): void {
+        $listShortUrls = $this->shortUrlService->listShortUrls($page, $searchTerm, $tags, null, $dateRange)
+            ->willReturn(new Paginator(new ArrayAdapter()));
+
+        $this->commandTester->setInputs(['n']);
+        $this->commandTester->execute($commandArgs);
+
+        $listShortUrls->shouldHaveBeenCalledOnce();
+    }
+
+    public function provideArgs(): iterable
+    {
+        yield [[], 1, null, [], new DateRange()];
+        yield [['--page' => $page = 3], $page, null, [], new DateRange()];
+        yield [['--searchTerm' => $searchTerm = 'search this'], 1, $searchTerm, [], new DateRange()];
+        yield [
+            ['--page' => $page = 3, '--searchTerm' => $searchTerm = 'search this', '--tags' => $tags = 'foo,bar'],
+            $page,
+            $searchTerm,
+            explode(',', $tags),
+            new DateRange(),
+        ];
+        yield [
+            ['--startDate' => $startDate = '2019-01-01'],
+            1,
+            null,
+            [],
+            new DateRange(Chronos::parse($startDate)),
+        ];
+        yield [
+            ['--endDate' => $endDate = '2020-05-23'],
+            1,
+            null,
+            [],
+            new DateRange(null, Chronos::parse($endDate)),
+        ];
+        yield [
+            ['--startDate' => $startDate = '2019-01-01', '--endDate' => $endDate = '2020-05-23'],
+            1,
+            null,
+            [],
+            new DateRange(Chronos::parse($startDate), Chronos::parse($endDate)),
+        ];
     }
 }

--- a/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
+++ b/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
@@ -162,4 +162,27 @@ class ListShortUrlsCommandTest extends TestCase
             new DateRange(Chronos::parse($startDate), Chronos::parse($endDate)),
         ];
     }
+
+    /**
+     * @test
+     * @dataProvider provideOrderBy
+     */
+    public function orderByIsProperlyComputed(array $commandArgs, $expectedOrderBy): void
+    {
+        $listShortUrls = $this->shortUrlService->listShortUrls(1, null, [], $expectedOrderBy, new DateRange())
+            ->willReturn(new Paginator(new ArrayAdapter()));
+
+        $this->commandTester->setInputs(['n']);
+        $this->commandTester->execute($commandArgs);
+
+        $listShortUrls->shouldHaveBeenCalledOnce();
+    }
+
+    public function provideOrderBy(): iterable
+    {
+        yield [[], null];
+        yield [['--orderBy' => 'foo'], 'foo'];
+        yield [['--orderBy' => 'foo,ASC'], ['foo' => 'ASC']];
+        yield [['--orderBy' => 'bar,DESC'], ['bar' => 'DESC']];
+    }
 }

--- a/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
+++ b/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
@@ -55,7 +55,7 @@ class ShortUrlRepositoryAdapter implements AdapterInterface
             $this->searchTerm,
             $this->tags,
             $this->orderBy,
-            $this->dateRange,
+            $this->dateRange
         );
     }
 

--- a/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
+++ b/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Paginator\Adapter;
 
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Repository\ShortUrlRepositoryInterface;
 use Zend\Paginator\Adapter\AdapterInterface;
 
@@ -22,17 +23,21 @@ class ShortUrlRepositoryAdapter implements AdapterInterface
     private $orderBy;
     /** @var array */
     private $tags;
+    /** @var DateRange|null */
+    private $dateRange;
 
     public function __construct(
         ShortUrlRepositoryInterface $repository,
         $searchTerm = null,
         array $tags = [],
-        $orderBy = null
+        $orderBy = null,
+        ?DateRange $dateRange = null
     ) {
         $this->repository = $repository;
         $this->searchTerm = $searchTerm !== null ? trim(strip_tags($searchTerm)) : null;
         $this->orderBy = $orderBy;
         $this->tags = $tags;
+        $this->dateRange = $dateRange;
     }
 
     /**
@@ -49,7 +54,8 @@ class ShortUrlRepositoryAdapter implements AdapterInterface
             $offset,
             $this->searchTerm,
             $this->tags,
-            $this->orderBy
+            $this->orderBy,
+            $this->dateRange,
         );
     }
 

--- a/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
+++ b/module/Core/src/Paginator/Adapter/ShortUrlRepositoryAdapter.php
@@ -70,6 +70,6 @@ class ShortUrlRepositoryAdapter implements AdapterInterface
      */
     public function count(): int
     {
-        return $this->repository->countList($this->searchTerm, $this->tags);
+        return $this->repository->countList($this->searchTerm, $this->tags, $this->dateRange);
     }
 }

--- a/module/Core/src/Repository/ShortUrlRepository.php
+++ b/module/Core/src/Repository/ShortUrlRepository.php
@@ -54,15 +54,9 @@ class ShortUrlRepository extends EntityRepository implements ShortUrlRepositoryI
 
     private function processOrderByForList(QueryBuilder $qb, $orderBy): array
     {
-        // Map public field names to column names
-        $fieldNameMap = [
-            'originalUrl' => 'longUrl',
-            'longUrl' => 'longUrl',
-            'shortCode' => 'shortCode',
-            'dateCreated' => 'dateCreated',
-        ];
-        $fieldName = is_array($orderBy) ? key($orderBy) : $orderBy;
-        $order = is_array($orderBy) ? $orderBy[$fieldName] : 'ASC';
+        $isArray = is_array($orderBy);
+        $fieldName = $isArray ? key($orderBy) : $orderBy;
+        $order = $isArray ? $orderBy[$fieldName] : 'ASC';
 
         if (contains(['visits', 'visitsCount', 'visitCount'], $fieldName)) {
             $qb->addSelect('COUNT(DISTINCT v) AS totalVisits')
@@ -73,6 +67,13 @@ class ShortUrlRepository extends EntityRepository implements ShortUrlRepositoryI
             return array_column($qb->getQuery()->getResult(), 0);
         }
 
+        // Map public field names to column names
+        $fieldNameMap = [
+            'originalUrl' => 'longUrl',
+            'longUrl' => 'longUrl',
+            'shortCode' => 'shortCode',
+            'dateCreated' => 'dateCreated',
+        ];
         if (array_key_exists($fieldName, $fieldNameMap)) {
             $qb->orderBy('s.' . $fieldNameMap[$fieldName], $order);
         }

--- a/module/Core/src/Repository/ShortUrlRepositoryInterface.php
+++ b/module/Core/src/Repository/ShortUrlRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\Core\Repository;
 
 use Doctrine\Common\Persistence\ObjectRepository;
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 
 interface ShortUrlRepositoryInterface extends ObjectRepository
@@ -19,7 +20,8 @@ interface ShortUrlRepositoryInterface extends ObjectRepository
         ?int $offset = null,
         ?string $searchTerm = null,
         array $tags = [],
-        $orderBy = null
+        $orderBy = null,
+        ?DateRange $dateRange = null
     ): array;
 
     /**

--- a/module/Core/src/Repository/ShortUrlRepositoryInterface.php
+++ b/module/Core/src/Repository/ShortUrlRepositoryInterface.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Repository;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 
 interface ShortUrlRepositoryInterface extends ObjectRepository
 {
     /**
-     * Gets a list of elements using provided filtering data
-     *
      * @param string|array|null $orderBy
      */
     public function findList(
@@ -24,10 +22,7 @@ interface ShortUrlRepositoryInterface extends ObjectRepository
         ?DateRange $dateRange = null
     ): array;
 
-    /**
-     * Counts the number of elements in a list using provided filtering data
-     */
-    public function countList(?string $searchTerm = null, array $tags = []): int;
+    public function countList(?string $searchTerm = null, array $tags = [], ?DateRange $dateRange = null): int;
 
     public function findOneByShortCode(string $shortCode, ?string $domain = null): ?ShortUrl;
 

--- a/module/Core/src/Repository/TagRepositoryInterface.php
+++ b/module/Core/src/Repository/TagRepositoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Repository;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 
 interface TagRepositoryInterface extends ObjectRepository
 {

--- a/module/Core/src/Repository/VisitRepositoryInterface.php
+++ b/module/Core/src/Repository/VisitRepositoryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Repository;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\Visit;
 

--- a/module/Core/src/Service/ShortUrlService.php
+++ b/module/Core/src/Service/ShortUrlService.php
@@ -29,16 +29,18 @@ class ShortUrlService implements ShortUrlServiceInterface
     }
 
     /**
-     * @param int $page
-     * @param string|null $searchQuery
      * @param string[] $tags
      * @param array|string|null $orderBy
-     * @param DateRange|null $dateRange
      *
      * @return ShortUrl[]|Paginator
      */
-    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null, ?DateRange $dateRange = null)
-    {
+    public function listShortUrls(
+        int $page = 1,
+        ?string $searchQuery = null,
+        array $tags = [],
+        $orderBy = null,
+        ?DateRange $dateRange = null
+    ) {
         /** @var ShortUrlRepository $repo */
         $repo = $this->em->getRepository(ShortUrl::class);
         $paginator = new Paginator(new ShortUrlRepositoryAdapter($repo, $searchQuery, $tags, $orderBy, $dateRange));

--- a/module/Core/src/Service/ShortUrlService.php
+++ b/module/Core/src/Service/ShortUrlService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\Core\Service;
 
 use Doctrine\ORM;
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
 use Shlinkio\Shlink\Core\Model\ShortUrlMeta;
@@ -28,15 +29,19 @@ class ShortUrlService implements ShortUrlServiceInterface
     }
 
     /**
+     * @param int $page
+     * @param string|null $searchQuery
      * @param string[] $tags
      * @param array|string|null $orderBy
+     * @param DateRange|null $dateRange
+     *
      * @return ShortUrl[]|Paginator
      */
-    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null)
+    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null, ?DateRange $dateRange = null)
     {
         /** @var ShortUrlRepository $repo */
         $repo = $this->em->getRepository(ShortUrl::class);
-        $paginator = new Paginator(new ShortUrlRepositoryAdapter($repo, $searchQuery, $tags, $orderBy));
+        $paginator = new Paginator(new ShortUrlRepositoryAdapter($repo, $searchQuery, $tags, $orderBy, $dateRange));
         $paginator->setItemCountPerPage(ShortUrlRepositoryAdapter::ITEMS_PER_PAGE)
                   ->setCurrentPageNumber($page);
 

--- a/module/Core/src/Service/ShortUrlServiceInterface.php
+++ b/module/Core/src/Service/ShortUrlServiceInterface.php
@@ -13,16 +13,18 @@ use Zend\Paginator\Paginator;
 interface ShortUrlServiceInterface
 {
     /**
-     * @param int $page
-     * @param string|null $searchQuery
      * @param string[] $tags
      * @param array|string|null $orderBy
-     * @return ShortUrl[]|Paginator
-     * @param DateRange|null $dateRange
      *
      * @return ShortUrl[]|Paginator
      */
-    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null, ?DateRange $dateRange = null);
+    public function listShortUrls(
+        int $page = 1,
+        ?string $searchQuery = null,
+        array $tags = [],
+        $orderBy = null,
+        ?DateRange $dateRange = null
+    );
 
     /**
      * @param string[] $tags

--- a/module/Core/src/Service/ShortUrlServiceInterface.php
+++ b/module/Core/src/Service/ShortUrlServiceInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Service;
 
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
 use Shlinkio\Shlink\Core\Model\ShortUrlMeta;
@@ -12,11 +13,16 @@ use Zend\Paginator\Paginator;
 interface ShortUrlServiceInterface
 {
     /**
+     * @param int $page
+     * @param string|null $searchQuery
      * @param string[] $tags
      * @param array|string|null $orderBy
      * @return ShortUrl[]|Paginator
+     * @param DateRange|null $dateRange
+     *
+     * @return ShortUrl[]|Paginator
      */
-    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null);
+    public function listShortUrls(int $page = 1, ?string $searchQuery = null, array $tags = [], $orderBy = null, ?DateRange $dateRange = null);
 
     /**
      * @param string[] $tags

--- a/module/Core/test/Domain/Resolver/PersistenceDomainResolverTest.php
+++ b/module/Core/test/Domain/Resolver/PersistenceDomainResolverTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ShlinkioTest\Shlink\Core\Domain\Resolver;
 
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Shlinkio\Shlink\Core\Domain\Resolver\PersistenceDomainResolver;

--- a/module/Core/test/Paginator/Adapter/ShortUrlRepositoryAdapterTest.php
+++ b/module/Core/test/Paginator/Adapter/ShortUrlRepositoryAdapterTest.php
@@ -4,35 +4,63 @@ declare(strict_types=1);
 
 namespace ShlinkioTest\Shlink\Core\Paginator\Adapter;
 
+use Cake\Chronos\Chronos;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Paginator\Adapter\ShortUrlRepositoryAdapter;
 use Shlinkio\Shlink\Core\Repository\ShortUrlRepositoryInterface;
 
 class ShortUrlRepositoryAdapterTest extends TestCase
 {
-    /** @var ShortUrlRepositoryAdapter */
-    private $adapter;
     /** @var ObjectProphecy */
     private $repo;
 
     public function setUp(): void
     {
         $this->repo = $this->prophesize(ShortUrlRepositoryInterface::class);
-        $this->adapter = new ShortUrlRepositoryAdapter($this->repo->reveal(), 'search', ['foo', 'bar'], 'order');
     }
 
-    /** @test */
-    public function getItemsFallbacksToFindList(): void
-    {
-        $this->repo->findList(10, 5, 'search', ['foo', 'bar'], 'order', null)->shouldBeCalledOnce();
-        $this->adapter->getItems(5, 10);
+    /**
+     * @test
+     * @dataProvider provideFilteringArgs
+     */
+    public function getItemsFallsBackToFindList(
+        $searchTerm = null,
+        array $tags = [],
+        ?DateRange $dateRange = null,
+        $orderBy = null
+    ): void {
+        $adapter = new ShortUrlRepositoryAdapter($this->repo->reveal(), $searchTerm, $tags, $orderBy, $dateRange);
+
+        $this->repo->findList(10, 5, $searchTerm, $tags, $orderBy, $dateRange)->shouldBeCalledOnce();
+        $adapter->getItems(5, 10);
     }
 
-    /** @test */
-    public function countFallbacksToCountList(): void
+    /**
+     * @test
+     * @dataProvider provideFilteringArgs
+     */
+    public function countFallsBackToCountList($searchTerm = null, array $tags = [], ?DateRange $dateRange = null): void
     {
-        $this->repo->countList('search', ['foo', 'bar'])->shouldBeCalledOnce();
-        $this->adapter->count();
+        $adapter = new ShortUrlRepositoryAdapter($this->repo->reveal(), $searchTerm, $tags, null, $dateRange);
+
+        $this->repo->countList($searchTerm, $tags, $dateRange)->shouldBeCalledOnce();
+        $adapter->count();
+    }
+
+    public function provideFilteringArgs(): iterable
+    {
+        yield [];
+        yield ['search'];
+        yield ['search', []];
+        yield ['search', ['foo', 'bar']];
+        yield ['search', ['foo', 'bar'], null, 'order'];
+        yield ['search', ['foo', 'bar'], new DateRange(), 'order'];
+        yield ['search', ['foo', 'bar'], new DateRange(Chronos::now()), 'order'];
+        yield ['search', ['foo', 'bar'], new DateRange(null, Chronos::now()), 'order'];
+        yield ['search', ['foo', 'bar'], new DateRange(Chronos::now(), Chronos::now()), 'order'];
+        yield ['search', ['foo', 'bar'], new DateRange(Chronos::now())];
+        yield [null, ['foo', 'bar'], new DateRange(Chronos::now(), Chronos::now())];
     }
 }

--- a/module/Core/test/Paginator/Adapter/ShortUrlRepositoryAdapterTest.php
+++ b/module/Core/test/Paginator/Adapter/ShortUrlRepositoryAdapterTest.php
@@ -25,7 +25,7 @@ class ShortUrlRepositoryAdapterTest extends TestCase
     /** @test */
     public function getItemsFallbacksToFindList(): void
     {
-        $this->repo->findList(10, 5, 'search', ['foo', 'bar'], 'order')->shouldBeCalledOnce();
+        $this->repo->findList(10, 5, 'search', ['foo', 'bar'], 'order', null)->shouldBeCalledOnce();
         $this->adapter->getItems(5, 10);
     }
 

--- a/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
+++ b/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
@@ -58,19 +58,20 @@ class ListShortUrlsAction extends AbstractRestAction
      */
     private function queryToListParams(array $query): array
     {
-        $dateRange = null;
-        $startDate = isset($query['startDate']) ? Chronos::parse($query['startDate']) : null;
-        $endDate = isset($query['endDate']) ? Chronos::parse($query['endDate']) : null;
-        if ($startDate !== null || $endDate !== null) {
-            $dateRange = new DateRange($startDate, $endDate);
-        }
-
         return [
             (int) ($query['page'] ?? 1),
             $query['searchTerm'] ?? null,
             $query['tags'] ?? [],
             $query['orderBy'] ?? null,
-            $dateRange,
+            $this->determineDateRangeFromQuery($query),
         ];
+    }
+
+    private function determineDateRangeFromQuery(array $query): DateRange
+    {
+        return new DateRange(
+            isset($query['startDate']) ? Chronos::parse($query['startDate']) : null,
+            isset($query['endDate']) ? Chronos::parse($query['endDate']) : null
+        );
     }
 }

--- a/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
+++ b/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
@@ -59,10 +59,10 @@ class ListShortUrlsAction extends AbstractRestAction
     private function queryToListParams(array $query): array
     {
         $dateRange = null;
-        $dateStart = isset($query['dateStart']) ? Chronos::parse($query['dateStart']) : null;
-        $dateEnd = isset($query['dateEnd']) ? Chronos::parse($query['dateEnd']) : null;
-        if ($dateStart != null || $dateEnd != null) {
-            $dateRange = new DateRange($dateStart, $dateEnd);
+        $startDate = isset($query['startDate']) ? Chronos::parse($query['startDate']) : null;
+        $endDate = isset($query['endDate']) ? Chronos::parse($query['endDate']) : null;
+        if ($startDate != null || $endDate != null) {
+            $dateRange = new DateRange($startDate, $endDate);
         }
 
         return [

--- a/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
+++ b/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Rest\Action\ShortUrl;
 
+use Cake\Chronos\Chronos;
 use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Log\LoggerInterface;
 use Shlinkio\Shlink\Common\Paginator\Util\PaginatorUtilsTrait;
+use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Service\ShortUrlServiceInterface;
 use Shlinkio\Shlink\Core\Transformer\ShortUrlDataTransformer;
 use Shlinkio\Shlink\Rest\Action\AbstractRestAction;
@@ -56,11 +58,19 @@ class ListShortUrlsAction extends AbstractRestAction
      */
     private function queryToListParams(array $query): array
     {
+        $dateRange = null;
+        $dateStart = isset($query['dateStart']) ? Chronos::parse($query['dateStart']) : null;
+        $dateEnd = isset($query['dateEnd']) ? Chronos::parse($query['dateEnd']) : null;
+        if ($dateStart != null || $dateEnd != null) {
+            $dateRange = new DateRange($dateStart, $dateEnd);
+        }
+
         return [
             (int) ($query['page'] ?? 1),
             $query['searchTerm'] ?? null,
             $query['tags'] ?? [],
             $query['orderBy'] ?? null,
+            $dateRange,
         ];
     }
 }

--- a/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
+++ b/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
@@ -61,7 +61,7 @@ class ListShortUrlsAction extends AbstractRestAction
         $dateRange = null;
         $startDate = isset($query['startDate']) ? Chronos::parse($query['startDate']) : null;
         $endDate = isset($query['endDate']) ? Chronos::parse($query['endDate']) : null;
-        if ($startDate != null || $endDate != null) {
+        if ($startDate !== null || $endDate !== null) {
             $dateRange = new DateRange($startDate, $endDate);
         }
 

--- a/module/Rest/test-api/Action/ListShortUrlsTest.php
+++ b/module/Rest/test-api/Action/ListShortUrlsTest.php
@@ -4,107 +4,160 @@ declare(strict_types=1);
 
 namespace ShlinkioApiTest\Shlink\Rest\Action;
 
+use Cake\Chronos\Chronos;
+use GuzzleHttp\RequestOptions;
 use Shlinkio\Shlink\TestUtils\ApiTest\ApiTestCase;
+
+use function count;
 
 class ListShortUrlsTest extends ApiTestCase
 {
-    /** @test */
-    public function shortUrlsAreProperlyListed(): void
+    private const SHORT_URL_SHLINK = [
+        'shortCode' => 'abc123',
+        'shortUrl' => 'http://doma.in/abc123',
+        'longUrl' => 'https://shlink.io',
+        'dateCreated' => '2018-05-01T00:00:00+00:00',
+        'visitsCount' => 3,
+        'tags' => ['foo'],
+        'meta' => [
+            'validSince' => null,
+            'validUntil' => null,
+            'maxVisits' => null,
+        ],
+        'originalUrl' => 'https://shlink.io',
+    ];
+    private const SHORT_URL_CUSTOM_SLUG_AND_DOMAIN = [
+        'shortCode' => 'custom-with-domain',
+        'shortUrl' => 'http://some-domain.com/custom-with-domain',
+        'longUrl' => 'https://google.com',
+        'dateCreated' => '2018-10-20T00:00:00+00:00',
+        'visitsCount' => 0,
+        'tags' => [],
+        'meta' => [
+            'validSince' => null,
+            'validUntil' => null,
+            'maxVisits' => null,
+        ],
+        'originalUrl' => 'https://google.com',
+    ];
+    private const SHORT_URL_META = [
+        'shortCode' => 'def456',
+        'shortUrl' => 'http://doma.in/def456',
+        'longUrl' =>
+            'https://blog.alejandrocelaya.com/2017/12/09'
+            . '/acmailer-7-0-the-most-important-release-in-a-long-time/',
+        'dateCreated' => '2019-01-01T00:00:00+00:00',
+        'visitsCount' => 2,
+        'tags' => ['bar', 'foo'],
+        'meta' => [
+            'validSince' => '2020-05-01T00:00:00+00:00',
+            'validUntil' => null,
+            'maxVisits' => null,
+        ],
+        'originalUrl' =>
+            'https://blog.alejandrocelaya.com/2017/12/09'
+            . '/acmailer-7-0-the-most-important-release-in-a-long-time/',
+    ];
+    private const SHORT_URL_CUSTOM_SLUG = [
+        'shortCode' => 'custom',
+        'shortUrl' => 'http://doma.in/custom',
+        'longUrl' => 'https://shlink.io',
+        'dateCreated' => '2019-01-01T00:00:00+00:00',
+        'visitsCount' => 0,
+        'tags' => [],
+        'meta' => [
+            'validSince' => null,
+            'validUntil' => null,
+            'maxVisits' => 2,
+        ],
+        'originalUrl' => 'https://shlink.io',
+    ];
+    private const SHORT_URL_CUSTOM_DOMAIN = [
+        'shortCode' => 'ghi789',
+        'shortUrl' => 'http://example.com/ghi789',
+        'longUrl' =>
+            'https://blog.alejandrocelaya.com/2019/04/27'
+            . '/considerations-to-properly-use-open-source-software-projects/',
+        'dateCreated' => '2019-01-01T00:00:00+00:00',
+        'visitsCount' => 0,
+        'tags' => [],
+        'meta' => [
+            'validSince' => null,
+            'validUntil' => null,
+            'maxVisits' => null,
+        ],
+        'originalUrl' =>
+            'https://blog.alejandrocelaya.com/2019/04/27'
+            . '/considerations-to-properly-use-open-source-software-projects/',
+    ];
+
+    /**
+     * @test
+     * @dataProvider provideFilteredLists
+     */
+    public function shortUrlsAreProperlyListed(array $query, array $expectedShortUrls): void
     {
-        $resp = $this->callApiWithKey(self::METHOD_GET, '/short-urls');
+        $resp = $this->callApiWithKey(self::METHOD_GET, '/short-urls', [RequestOptions::QUERY => $query]);
         $respPayload = $this->getJsonResponsePayload($resp);
 
         $this->assertEquals(self::STATUS_OK, $resp->getStatusCode());
         $this->assertEquals([
             'shortUrls' => [
-                'data' => [
-                    [
-                        'shortCode' => 'abc123',
-                        'shortUrl' => 'http://doma.in/abc123',
-                        'longUrl' => 'https://shlink.io',
-                        'dateCreated' => '2019-01-01T00:00:00+00:00',
-                        'visitsCount' => 3,
-                        'tags' => ['foo'],
-                        'meta' => [
-                            'validSince' => null,
-                            'validUntil' => null,
-                            'maxVisits' => null,
-                        ],
-                        'originalUrl' => 'https://shlink.io',
-                    ],
-                    [
-                        'shortCode' => 'def456',
-                        'shortUrl' => 'http://doma.in/def456',
-                        'longUrl' =>
-                            'https://blog.alejandrocelaya.com/2017/12/09'
-                            . '/acmailer-7-0-the-most-important-release-in-a-long-time/',
-                        'dateCreated' => '2019-01-01T00:00:00+00:00',
-                        'visitsCount' => 2,
-                        'tags' => ['bar', 'foo'],
-                        'meta' => [
-                            'validSince' => '2020-05-01T00:00:00+00:00',
-                            'validUntil' => null,
-                            'maxVisits' => null,
-                        ],
-                        'originalUrl' =>
-                            'https://blog.alejandrocelaya.com/2017/12/09'
-                            . '/acmailer-7-0-the-most-important-release-in-a-long-time/',
-                    ],
-                    [
-                        'shortCode' => 'custom',
-                        'shortUrl' => 'http://doma.in/custom',
-                        'longUrl' => 'https://shlink.io',
-                        'dateCreated' => '2019-01-01T00:00:00+00:00',
-                        'visitsCount' => 0,
-                        'tags' => [],
-                        'meta' => [
-                            'validSince' => null,
-                            'validUntil' => null,
-                            'maxVisits' => 2,
-                        ],
-                        'originalUrl' => 'https://shlink.io',
-                    ],
-                    [
-                        'shortCode' => 'ghi789',
-                        'shortUrl' => 'http://example.com/ghi789',
-                        'longUrl' =>
-                            'https://blog.alejandrocelaya.com/2019/04/27'
-                            . '/considerations-to-properly-use-open-source-software-projects/',
-                        'dateCreated' => '2019-01-01T00:00:00+00:00',
-                        'visitsCount' => 0,
-                        'tags' => [],
-                        'meta' => [
-                            'validSince' => null,
-                            'validUntil' => null,
-                            'maxVisits' => null,
-                        ],
-                        'originalUrl' =>
-                            'https://blog.alejandrocelaya.com/2019/04/27'
-                            . '/considerations-to-properly-use-open-source-software-projects/',
-                    ],
-                    [
-                        'shortCode' => 'custom-with-domain',
-                        'shortUrl' => 'http://some-domain.com/custom-with-domain',
-                        'longUrl' => 'https://google.com',
-                        'dateCreated' => '2019-01-01T00:00:00+00:00',
-                        'visitsCount' => 0,
-                        'tags' => [],
-                        'meta' => [
-                            'validSince' => null,
-                            'validUntil' => null,
-                            'maxVisits' => null,
-                        ],
-                        'originalUrl' => 'https://google.com',
-                    ],
-                ],
-                'pagination' => [
-                    'currentPage' => 1,
-                    'pagesCount' => 1,
-                    'itemsPerPage' => 10,
-                    'itemsInCurrentPage' => 5,
-                    'totalItems' => 5,
-                ],
+                'data' => $expectedShortUrls,
+                'pagination' => $this->buildPagination(count($expectedShortUrls)),
             ],
         ], $respPayload);
+    }
+
+    public function provideFilteredLists(): iterable
+    {
+        yield [[], [
+            self::SHORT_URL_SHLINK,
+            self::SHORT_URL_CUSTOM_SLUG_AND_DOMAIN,
+            self::SHORT_URL_META,
+            self::SHORT_URL_CUSTOM_SLUG,
+            self::SHORT_URL_CUSTOM_DOMAIN,
+        ]];
+        yield [['orderBy' => 'shortCode'], [
+            self::SHORT_URL_SHLINK,
+            self::SHORT_URL_CUSTOM_SLUG,
+            self::SHORT_URL_CUSTOM_SLUG_AND_DOMAIN,
+            self::SHORT_URL_META,
+            self::SHORT_URL_CUSTOM_DOMAIN,
+        ]];
+        yield [['startDate' => Chronos::parse('2018-12-01')->toAtomString()], [
+            self::SHORT_URL_META,
+            self::SHORT_URL_CUSTOM_SLUG,
+            self::SHORT_URL_CUSTOM_DOMAIN,
+        ]];
+        yield [['endDate' => Chronos::parse('2018-12-01')->toAtomString()], [
+            self::SHORT_URL_SHLINK,
+            self::SHORT_URL_CUSTOM_SLUG_AND_DOMAIN,
+        ]];
+        yield [['tags' => ['foo']], [
+            self::SHORT_URL_SHLINK,
+            self::SHORT_URL_META,
+        ]];
+        yield [['tags' => ['bar']], [
+            self::SHORT_URL_META,
+        ]];
+        yield [['tags' => ['foo'], 'endDate' => Chronos::parse('2018-12-01')->toAtomString()], [
+            self::SHORT_URL_SHLINK,
+        ]];
+        yield [['searchTerm' => 'alejandro'], [
+            self::SHORT_URL_META,
+            self::SHORT_URL_CUSTOM_DOMAIN,
+        ]];
+    }
+
+    private function buildPagination(int $itemsCount): array
+    {
+        return [
+            'currentPage' => 1,
+            'pagesCount' => 1,
+            'itemsPerPage' => 10,
+            'itemsInCurrentPage' => $itemsCount,
+            'totalItems' => $itemsCount,
+        ];
     }
 }

--- a/module/Rest/test-api/Fixtures/ApiKeyFixture.php
+++ b/module/Rest/test-api/Fixtures/ApiKeyFixture.php
@@ -6,7 +6,7 @@ namespace ShlinkioApiTest\Shlink\Rest\Fixtures;
 
 use Cake\Chronos\Chronos;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use ReflectionObject;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
 

--- a/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
@@ -6,7 +6,7 @@ namespace ShlinkioApiTest\Shlink\Rest\Fixtures;
 
 use Cake\Chronos\Chronos;
 use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use ReflectionObject;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Model\ShortUrlMeta;

--- a/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
@@ -21,7 +21,8 @@ class ShortUrlsFixture extends AbstractFixture
     public function load(ObjectManager $manager): void
     {
         $abcShortUrl = $this->setShortUrlDate(
-            new ShortUrl('https://shlink.io', ShortUrlMeta::createFromRawData(['customSlug' => 'abc123']))
+            new ShortUrl('https://shlink.io', ShortUrlMeta::createFromRawData(['customSlug' => 'abc123'])),
+            Chronos::parse('2018-05-01')
         );
         $manager->persist($abcShortUrl);
 
@@ -46,7 +47,7 @@ class ShortUrlsFixture extends AbstractFixture
         $withDomainAndSlugShortUrl = $this->setShortUrlDate(new ShortUrl(
             'https://google.com',
             ShortUrlMeta::createFromRawData(['domain' => 'some-domain.com', 'customSlug' => 'custom-with-domain'])
-        ));
+        ), Chronos::parse('2018-10-20'));
         $manager->persist($withDomainAndSlugShortUrl);
 
         $manager->flush();
@@ -55,12 +56,12 @@ class ShortUrlsFixture extends AbstractFixture
         $this->addReference('def456_short_url', $defShortUrl);
     }
 
-    private function setShortUrlDate(ShortUrl $shortUrl): ShortUrl
+    private function setShortUrlDate(ShortUrl $shortUrl, ?Chronos $date = null): ShortUrl
     {
         $ref = new ReflectionObject($shortUrl);
         $dateProp = $ref->getProperty('dateCreated');
         $dateProp->setAccessible(true);
-        $dateProp->setValue($shortUrl, Chronos::create(2019, 1, 1, 0, 0, 0));
+        $dateProp->setValue($shortUrl, $date ?? Chronos::parse('2019-01-01'));
 
         return $shortUrl;
     }

--- a/module/Rest/test-api/Fixtures/TagsFixture.php
+++ b/module/Rest/test-api/Fixtures/TagsFixture.php
@@ -7,7 +7,7 @@ namespace ShlinkioApiTest\Shlink\Rest\Fixtures;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Entity\Tag;
 

--- a/module/Rest/test-api/Fixtures/VisitsFixture.php
+++ b/module/Rest/test-api/Fixtures/VisitsFixture.php
@@ -6,7 +6,7 @@ namespace ShlinkioApiTest\Shlink\Rest\Fixtures;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Entity\Visit;
 use Shlinkio\Shlink\Core\Model\Visitor;

--- a/module/Rest/test/Action/ShortUrl/ListShortUrlsActionTest.php
+++ b/module/Rest/test/Action/ShortUrl/ListShortUrlsActionTest.php
@@ -49,7 +49,8 @@ class ListShortUrlsActionTest extends TestCase
             $expectedPage,
             $expectedSearchTerm,
             $expectedTags,
-            $expectedOrderBy
+            $expectedOrderBy,
+            null
         )->willReturn(new Paginator(new ArrayAdapter()));
 
         /** @var JsonResponse $response */


### PR DESCRIPTION
These are new filters for the `GET /rest/v1/short-urls` endpoint. `startDate` and `endDate` are added as parameters to limit the results. It is useful to build reports on applications where the service has been running for several months.

Closes #575 