### PR TITLE
Update sample Nginx config to point to PHP 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Once Shlink is configured, you need to expose it to the web, either by using a t
 
         location ~ \.php$ {
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
-            fastcgi_pass unix:/var/run/php/php7.2-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
             fastcgi_index index.php;
             include fastcgi.conf;
         }


### PR DESCRIPTION
The README file currently provides a sample Nginx config that uses PHP 7.2. As Shlink now requires PHP 7.4 or above, the sample conflig should reflect that.