### PR TITLE
override alphabet with ENV VAR SHLINK_ALPHABET if exists

### DIFF
--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -28,6 +28,7 @@ function generateRandomShortCode(int $length): string
     }
 
     $alphabet = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    if ( getenv('SHLINK_ALPHABET') ) { $alphabet = getenv('SHLINK_ALPHABET'); } # override with ENV VAR
     return $shortIdFactory->generate($length, $alphabet)->serialize();
 }
 


### PR DESCRIPTION
Really simple addition to override the alphabet with ENV var SHLINK_ALPHABET if that env var exists.