### PR TITLE
Leave standard margin on QR code

### DIFF
--- a/module/Core/src/Action/QrCodeAction.php
+++ b/module/Core/src/Action/QrCodeAction.php
@@ -54,7 +54,7 @@ class QrCodeAction implements MiddlewareInterface
         $size = $this->normalizeSize((int) $request->getAttribute('size', $query['size'] ?? self::DEFAULT_SIZE));
 
         $qrCode = new QrCode($this->stringifier->stringify($shortUrl));
-        $qrCode->setSize($size);
+        $qrCode->setSize($size - 2 * $qrCode->getMargin());
 
         $format = $query['format'] ?? 'png';
         if ($format === 'svg') {

--- a/module/Core/src/Action/QrCodeAction.php
+++ b/module/Core/src/Action/QrCodeAction.php
@@ -55,7 +55,6 @@ class QrCodeAction implements MiddlewareInterface
 
         $qrCode = new QrCode($this->stringifier->stringify($shortUrl));
         $qrCode->setSize($size);
-        $qrCode->setMargin(0);
 
         $format = $query['format'] ?? 'png';
         if ($format === 'svg') {


### PR DESCRIPTION
Removing the margin from the QR code image is okay when you're displaying the image on a white background and adding margin another way, e.g. using CSS as in the web client. However, if you need to use the generated image in another medium, especially one with a dark background, the lack of whitespace around the grid can slow detection or make it unreadable, depending on the algorithm used and quality of the image taken by the camera. It's safest to leave the default margin in.