### PR TITLE
Create volume for /etc/shlink/data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,8 @@ EXPOSE 8080
 
 # Expose params config dir, since the user is expected to provide custom config from there
 VOLUME /etc/shlink/config/params
+# Expose data to have it persistent when using shlink as a docker service or similar
+VOLUME /etc/shlink/data
 
 # Copy config specific for the image
 COPY docker/docker-entrypoint.sh docker-entrypoint.sh


### PR DESCRIPTION
Makes it so shlink can be used as a docker service without losing ur data every time,
also provides easy access to the data folder incase it needs to be backed up.