### PR TITLE
Feature/show API key info in short-url CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
     Also, when using swoole, the file is now updated **after** tracking a visit, which means it will not apply until the next one.
 
+* [#1059](https://github.com/shlinkio/shlink/issues/1059) Added ability to optionally display author API key and its name when listing short URLs from the command line.
+
 ### Changed
 * [#1036](https://github.com/shlinkio/shlink/issues/1036) Updated to `happyr/doctrine-specification` 2.0.
 * [#1039](https://github.com/shlinkio/shlink/issues/1039) Updated to `endroid/qr-code` 4.0.

--- a/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
+++ b/module/CLI/test/Command/ShortUrl/ListShortUrlsCommandTest.php
@@ -12,13 +12,17 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Shlinkio\Shlink\CLI\Command\ShortUrl\ListShortUrlsCommand;
 use Shlinkio\Shlink\Common\Paginator\Paginator;
 use Shlinkio\Shlink\Core\Entity\ShortUrl;
+use Shlinkio\Shlink\Core\Model\ShortUrlMeta;
 use Shlinkio\Shlink\Core\Model\ShortUrlsParams;
 use Shlinkio\Shlink\Core\Service\ShortUrlServiceInterface;
 use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifier;
 use Shlinkio\Shlink\Core\ShortUrl\Transformer\ShortUrlDataTransformer;
+use Shlinkio\Shlink\Rest\ApiKey\Model\ApiKeyMeta;
+use Shlinkio\Shlink\Rest\Entity\ApiKey;
 use ShlinkioTest\Shlink\CLI\CliTestUtilsTrait;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function count;
 use function explode;
 
 class ListShortUrlsCommandTest extends TestCase
@@ -98,17 +102,77 @@ class ListShortUrlsCommandTest extends TestCase
         $this->commandTester->execute(['--page' => $page]);
     }
 
-    /** @test */
-    public function ifTagsFlagIsProvidedTagsColumnIsIncluded(): void
-    {
+    /**
+     * @test
+     * @dataProvider provideOptionalFlags
+     */
+    public function provideOptionalFlagsMakesNewColumnsToBeIncluded(
+        array $input,
+        array $expectedContents,
+        array $notExpectedContents,
+        ApiKey $apiKey
+    ): void {
         $this->shortUrlService->listShortUrls(ShortUrlsParams::emptyInstance())
-            ->willReturn(new Paginator(new ArrayAdapter([])))
+            ->willReturn(new Paginator(new ArrayAdapter([
+                ShortUrl::fromMeta(ShortUrlMeta::fromRawData([
+                    'longUrl' => 'foo.com',
+                    'tags' => ['foo', 'bar', 'baz'],
+                    'apiKey' => $apiKey,
+                ])),
+            ])))
             ->shouldBeCalledOnce();
 
         $this->commandTester->setInputs(['y']);
-        $this->commandTester->execute(['--show-tags' => true]);
+        $this->commandTester->execute($input);
         $output = $this->commandTester->getDisplay();
-        self::assertStringContainsString('Tags', $output);
+
+        if (count($expectedContents) === 0 && count($notExpectedContents) === 0) {
+            self::fail('No expectations were run');
+        }
+
+        foreach ($expectedContents as $column) {
+            self::assertStringContainsString($column, $output);
+        }
+        foreach ($notExpectedContents as $column) {
+            self::assertStringNotContainsString($column, $output);
+        }
+    }
+
+    public function provideOptionalFlags(): iterable
+    {
+        $apiKey = ApiKey::fromMeta(ApiKeyMeta::withName('my api key'));
+        $key = $apiKey->toString();
+
+        yield 'tags only' => [
+            ['--show-tags' => true],
+            ['| Tags    ', '| foo, bar, baz'],
+            ['| API Key    ', '| API Key Name |', $key, '| my api key'],
+            $apiKey,
+        ];
+        yield 'api key only' => [
+            ['--show-api-key' => true],
+            ['| API Key    ', $key],
+            ['| Tags    ', '| foo, bar, baz', '| API Key Name |', '| my api key'],
+            $apiKey,
+        ];
+        yield 'api key name only' => [
+            ['--show-api-key-name' => true],
+            ['| API Key Name |', '| my api key'],
+            ['| Tags    ', '| foo, bar, baz', '| API Key    ', $key],
+            $apiKey,
+        ];
+        yield 'tags and api key' => [
+            ['--show-tags' => true, '--show-api-key' => true],
+            ['| API Key    ', '| Tags    ', '| foo, bar, baz', $key],
+            ['| API Key Name |', '| my api key'],
+            $apiKey,
+        ];
+        yield 'all' => [
+            ['--show-tags' => true, '--show-api-key' => true, '--show-api-key-name' => true],
+            ['| API Key    ', '| Tags    ', '| API Key Name |', '| foo, bar, baz', $key, '| my api key'],
+            [],
+            $apiKey,
+        ];
     }
 
     /**

--- a/module/Core/src/Entity/ShortUrl.php
+++ b/module/Core/src/Entity/ShortUrl.php
@@ -132,6 +132,11 @@ class ShortUrl extends AbstractEntity
         return $this->tags;
     }
 
+    public function authorApiKey(): ?ApiKey
+    {
+        return $this->authorApiKey;
+    }
+
     public function getValidSince(): ?Chronos
     {
         return $this->validSince;


### PR DESCRIPTION
Addresses #1059.

Adds two new CLI flags:

* `--show-api-key`
* `--show-api-key-name`

---

Data from development:

```shell
$ ./indocker bin/cli short-url:list --all --show-api-key --show-api-key-name
+------------+-------+-----------------------------+-----------------------------------------------------------------+---------------------------+--------------+--------------------------------------+---------------+
| Short Code | Title | Short URL                   | Long URL                                                        | Date created              | Visits count | API Key                              | API Key Name  |
+------------+-------+-----------------------------+-----------------------------------------------------------------+---------------------------+--------------+--------------------------------------+---------------+
| RGhvf      |       | http://localhost:8080/RGhvf | https://github.com/shlinkio/shlink/issues/1059                  | 2021-04-02T04:47:07+00:00 | 0            | 3e17f144-e349-4f12-96a2-6f058abdff25 |               |
| cLciN      |       | http://localhost:8080/cLciN | https://github.com/shlinkio/shlink/blob/develop/CONTRIBUTING.md | 2021-04-02T04:51:44+00:00 | 0            | 3d8a7c8d-e2bc-47ce-b66f-af0b84f92587 | Alice and Bob |
| 0IcFP      |       | http://localhost:8080/0IcFP | https://github.com/KetchupBomb/shlink                           | 2021-04-02T04:52:17+00:00 | 0            | db67d697-c85a-4ded-8170-67b1e7b51c61 |               |
| vaYMW      |       | http://localhost:8080/vaYMW | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:26+00:00 | 0            | e1a0b5a3-abe0-4940-971c-3e66c7408464 |               |
| dccBh      |       | http://localhost:8080/dccBh | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:27+00:00 | 0            | 55340df1-fe96-4182-a40c-1bead370d285 | Foobar        |
| 6Q2lr      |       | http://localhost:8080/6Q2lr | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:28+00:00 | 0            | 60156032-76f5-4e31-be06-baf15ea3adae |               |
| BFrcq      |       | http://localhost:8080/BFrcq | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:28+00:00 | 0            |                                      |               |
| N2qTV      |       | http://localhost:8080/N2qTV | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:28+00:00 | 0            | 55340df1-fe96-4182-a40c-1bead370d285 | Foobar        |
| t1kwF      |       | http://localhost:8080/t1kwF | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:29+00:00 | 0            | 55340df1-fe96-4182-a40c-1bead370d285 | Foobar        |
| kZXKC      |       | http://localhost:8080/kZXKC | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:29+00:00 | 0            | 55340df1-fe96-4182-a40c-1bead370d285 | Foobar        |
| 80eEF      |       | http://localhost:8080/80eEF | https://github.com/KetchupBomb/shlink/tree/main                 | 2021-04-02T04:52:30+00:00 | 0            |                                      |               |
+------------+-------+-----------------------------+-----------------------------------------------------------------+---------------------------+--------------+--------------------------------------+---------------+


                                                                                                                        
 [OK] Short URLs properly listed                                                                                        
                                                                                                                        
```

Currently, if there is no API key or API key name associated, it's a blank entry. This matches existing logic within `short-url:list` (like `Title`), but doesn't match other commands like `api-key:list`, where empty entries are represented with `-`. I'm leaving this discrepancy unaddressed in this diff.