### PR TITLE
Allow toggling deletion threshold in docker

### DIFF
--- a/docker/config/shlink_in_docker.local.php
+++ b/docker/config/shlink_in_docker.local.php
@@ -99,7 +99,7 @@ return [
     ],
 
     'delete_short_urls' => [
-        'check_visits_threshold' => true,
+        'check_visits_threshold' => (bool) env('ENABLE_DELETE_SHORT_URL_THRESHOLD', true),
         'visits_threshold' => (int) env('DELETE_SHORT_URL_THRESHOLD', DEFAULT_DELETE_SHORT_URL_THRESHOLD),
     ],
 


### PR DESCRIPTION
*Using `ENABLE_DELETE_SHORT_URL_THRESHOLD=false`, you too can enable shoot-yourself-in-the-foot-mode!*

More seriously I think this is the only option that isn't configurable in the docker image.
(I know setting `DELETE_SHORT_URL_THRESHOLD` to `PHP_INT_MAX` would have a similar effect but feels so *dirty*, particularly when you have `check_visits_threshold` right there)

Ref #1077