### PR TITLE
Run periodic `visit:locate` as opt-in

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,7 +23,7 @@ fi
 
 # Periodicaly run visit:locate every hour
 # https://shlink.io/documentation/long-running-tasks/#locate-visits
-# set env var "ENABLE_PERIODIC_VISIT_LOCATE=1" to enable
+# set env var "ENABLE_PERIODIC_VISIT_LOCATE=true" to enable
 if [ $ENABLE_PERIODIC_VISIT_LOCATE ]; then
   echo "Starting periodic visite locate..."
   echo "0 * * * * php /etc/shlink/bin/cli visit:locate -q" > /etc/crontabs/root

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,6 +21,15 @@ if [ ! -z "${GEOLITE_LICENSE_KEY}" ]; then
   php bin/cli visit:download-db -n -q
 fi
 
+# Periodicaly run visit:locate every hour
+# https://shlink.io/documentation/long-running-tasks/#locate-visits
+# set env var "ENABLE_PERIODIC_VISIT_LOCATE=1" to enable
+if [ $ENABLE_PERIODIC_VISIT_LOCATE ]; then
+  echo "Starting periodic visite locate..."
+  echo "0 * * * * php bin/cli visit:locate -q" > /etc/crontabs/root
+  /usr/sbin/crond &
+fi
+
 # When restarting the container, swoole might think it is already in execution
 # This forces the app to be started every second until the exit code is 0
 until php vendor/bin/laminas mezzio:swoole:start; do sleep 1 ; done

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -26,7 +26,7 @@ fi
 # set env var "ENABLE_PERIODIC_VISIT_LOCATE=1" to enable
 if [ $ENABLE_PERIODIC_VISIT_LOCATE ]; then
   echo "Starting periodic visite locate..."
-  echo "0 * * * * php bin/cli visit:locate -q" > /etc/crontabs/root
+  echo "0 * * * * php /etc/shlink/bin/cli visit:locate -q" > /etc/crontabs/root
   /usr/sbin/crond &
 fi
 


### PR DESCRIPTION
Hello,

This pr adds the feature to automatically run `visit:locate` every hour using crond in the docker image (already present in alpine).

To enable set the environment variable `ENABLE_PERIODIC_VISIT_LOCATE=1`.

ex `docker-compose.yml`:
```yaml
...
services:
  shlink:
...
    environment:
      ENABLE_PERIODIC_VISIT_LOCATE: 1
...
```

Kind regards,
Mika

resolve #1089 
