### PR TITLE
Change the Docker user to non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,11 @@ COPY docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.l
 COPY docker/config/php.ini ${PHP_INI_DIR}/conf.d/
 
 # Change the ownership of /etc/shlink/data to be writable, then change the user to non-root
-RUN chown 1001 -R /etc/shlink/data
+RUN chown 1001 /etc/shlink/data
+RUN chown 1001 /etc/shlink/data/locks
+RUN chown 1001 /etc/shlink/data/proxies
+RUN chown 1001 /etc/shlink/data/cache
+RUN chown 1001 /etc/shlink/data/log
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,9 @@ COPY docker/docker-entrypoint.sh docker-entrypoint.sh
 COPY docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.local.php
 COPY docker/config/php.ini ${PHP_INI_DIR}/conf.d/
 
+# Change the ownership of /etc/shlink/data to be writable, then change the user to non-root
+RUN chown 1001 -R /etc/shlink/data
+
+USER 1001
+
 ENTRYPOINT ["/bin/sh", "./docker-entrypoint.sh"]


### PR DESCRIPTION
There is absolutely no reason to make the user run as root at runtime, and poses a security liability. This PR changes the only relevant folders to be writable by the user ID 1001, then changes the default Docker user to 1001.

Ownership is set for individual folders rather than recursively, so the _migrations_ and _infra_ folders should effectively act as read-only.