### PR TITLE
Slight misuse of VOLUME in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,9 +69,9 @@ RUN ln -s /etc/shlink/bin/cli /usr/local/bin/shlink
 EXPOSE 8080
 
 # Expose params config dir, since the user is expected to provide custom config from there
-VOLUME /etc/shlink/config/params
+#VOLUME /etc/shlink/config/params
 # Expose data dir to allow persistent runtime data and SQLite db
-VOLUME /etc/shlink/data
+#VOLUME /etc/shlink/data
 
 # Copy config specific for the image
 COPY docker/docker-entrypoint.sh docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,11 +68,6 @@ RUN ln -s /etc/shlink/bin/cli /usr/local/bin/shlink
 # Expose default swoole port
 EXPOSE 8080
 
-# Expose params config dir, since the user is expected to provide custom config from there
-#VOLUME /etc/shlink/config/params
-# Expose data dir to allow persistent runtime data and SQLite db
-#VOLUME /etc/shlink/data
-
 # Copy config specific for the image
 COPY docker/docker-entrypoint.sh docker-entrypoint.sh
 COPY docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.local.php


### PR DESCRIPTION
Issuing a `VOLUME` instruction in a production Dockerfile requires the Docker engine to create a volume whether or not it is mapped to the host or a named volume. Neither of these paths have data that needs to be persisted for production use, so their inclusion under a typical `docker run` example forces the engine to create extraneous volumes which quickly become orphaned whenever the container is recreated.

I think this is a misunderstanding of how `VOLUME` works and what it should be used for. It is not used when defining a path where the user can inject their own configuration -- that is simply done via documentation. The user can always map volumes or host paths to arbitrary paths inside of the container regardless of the `VOLUME` instructions defined in the Dockerfile.

It should also not be used for runtime data unless this includes state that must persist across containers, say, when a production container is updated. Per the documentation, Shlink's sqlite database is not suitable for production use since it does not receive migrations when there is an update, and there is also no other mention in the documentation of needing to persist `/etc/shlink/data` for any other reason.

By way of example, here is my production service definition (docker-compose.yml):

```yaml
version: "3.8"

services:
  postgres:
    image: postgres
    environment:
      # Only used on initialization of data directory
      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
    volumes:
      - shlink_db:/var/lib/postgresql/data
    networks:
      - backend

  shlink:
    image: shlinkio/shlink:stable
    depends_on:
      - postgres
    environment:
      SHORT_DOMAIN_HOST: ${DOMAIN_NAME}
      SHORT_DOMAIN_SCHEMA: https
      DB_DRIVER: postgres
      DB_HOST: postgres
      DB_USER: postgres
      DB_PASSWORD: ${POSTGRES_PASSWORD}
    networks:
      - backend
      - nginx-proxy

networks:
  backend:
  nginx-proxy:
    name: nginx-proxy

volumes:
  shlink_db:
    name: shlink_db
```

Shlink has no volumes defined because it is documented to not require any, but the `VOLUME` instructions will still force the docker engine to create unnamed volumes for these two locations every time the container is recreated, like so:

![extraneous_volumes](https://user-images.githubusercontent.com/2458645/132957090-7442e3f3-c3f5-4e62-8b4e-9786e3312464.png)

If the `data/` dir is indeed used for production persistence then this is an important omission from the [documentation](https://shlink.io/documentation/install-docker-image/) and its VOLUME instruction should not be removed.