### PR TITLE
Enable persistent database volumes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 config/autoload/*local*
 data/infra
 data/cache/*
+data/db/*
 data/log/*
 data/locks/*
 data/proxies/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vendor/
 data/database.sqlite
 data/shlink-tests.db
 data/GeoLite2-City.*
+data/db/*
 docs/swagger-ui*
 docs/mercure.html
 docker-compose.override.yml

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -31,7 +31,7 @@ return (static function (): array {
     $resolveConnection = static fn () => match ($driver) {
         null, 'sqlite' => [
             'driver' => 'pdo_sqlite',
-            'path' => 'data/database.sqlite',
+            'path' => 'data/db/database.sqlite',
         ],
         default => [
             'driver' => $resolveDriver(),

--- a/config/autoload/geolite2.global.php
+++ b/config/autoload/geolite2.global.php
@@ -7,7 +7,7 @@ use Shlinkio\Shlink\Core\Config\EnvVars;
 return [
 
     'geolite2' => [
-        'db_location' => __DIR__ . '/../../data/GeoLite2-City.mmdb',
+        'db_location' => __DIR__ . '/../../data/db/GeoLite2-City.mmdb',
         'temp_dir' => __DIR__ . '/../../data',
         'license_key' => EnvVars::GEOLITE_LICENSE_KEY->loadFromEnv(),
     ],

--- a/data/db/.gitignore
+++ b/data/db/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -6,6 +6,10 @@ set -e
 
 cd /etc/shlink
 
+echo "Linking previous database if needed..."
+[ -f "data/database.sqlite" ] && ln -s "../database.sqlite" "data/db/"
+[ -f "data/GeoLite2-City.mmdb" ] && ln -s "../GeoLite2-City.mmdb" "data/db/"
+
 echo "Creating fresh database if needed..."
 php bin/cli db:create -n ${flags}
 


### PR DESCRIPTION
Moving databases into their own dedicated folder enables simple persistence with docker volumes.

Resolves shlinkio/shlink-docker-image#40, #681, #1238 

`docker-entrypoint.sh` provides backwards compatibility for those who have already mapped their existing databases.

For manual installations a note should be made in the next release about the changed paths.