### PR TITLE
Make shlink runnable as non root 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,14 +73,10 @@ COPY docker/docker-entrypoint.sh docker-entrypoint.sh
 COPY docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.local.php
 COPY docker/config/php.ini ${PHP_INI_DIR}/conf.d/
 
-# Change the ownership of /etc/shlink/data to be writable, then change the user to non-root
-# FIXME Disabled for now, as it conflicts with ENABLE_PERIODIC_VISIT_LOCATE, which is used to configure a cron as root.
-#       Ref: https://github.com/shlinkio/shlink/issues/1132
-#RUN chown 1001 /etc/shlink/data
-#RUN chown 1001 /etc/shlink/data/locks
-#RUN chown 1001 /etc/shlink/data/proxies
-#RUN chown 1001 /etc/shlink/data/cache
-#RUN chown 1001 /etc/shlink/data/log
-#USER 1001
+# Change the ownership of /etc/shlink to be writable, then change the user to non-root
+RUN chown -R 1001 /etc/shlink
+RUN chmod -R g=u /etc/shlink
+
+USER 1001
 
 ENTRYPOINT ["/bin/sh", "./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ RUN apk add --no-cache git && \
     sed -i "s/%SHLINK_VERSION%/${SHLINK_VERSION}/g" config/autoload/app_options.global.php
 
 
+RUN chown -R 1001 /etc/shlink && \
+  chmod -R g=u /etc/shlink
+
 # Prepare final image
 FROM base
 LABEL maintainer="Alejandro Celaya <alejandro@alejandrocelaya.com>"
@@ -69,13 +72,10 @@ RUN ln -s /etc/shlink/bin/cli /usr/local/bin/shlink && \
 EXPOSE 8080
 
 # Copy config specific for the image
-COPY docker/docker-entrypoint.sh docker-entrypoint.sh
-COPY docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.local.php
+COPY --chown=1001:0 --chmod=664 docker/docker-entrypoint.sh docker-entrypoint.sh
+COPY --chown=1001:0 --chmod=664 docker/config/shlink_in_docker.local.php config/autoload/shlink_in_docker.local.php
 COPY docker/config/php.ini ${PHP_INI_DIR}/conf.d/
 
-# Change the ownership of /etc/shlink to be writable, then change the user to non-root
-RUN chown -R 1001 /etc/shlink
-RUN chmod -R g=u /etc/shlink
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     docker-php-ext-install -j"$(nproc)" pdo_sqlite && \
     # Remove temp dev extensions, and install prod equivalents that are required at runtime
     apk del .dev-deps && \
-    apk add --no-cache postgresql icu libzip libpng
+    apk add --no-cache postgresql icu libzip libpng supercronic
 
 # Install openswoole and sqlsrv driver for x86_64 builds
 RUN apk add --no-cache --virtual .phpize-deps ${PHPIZE_DEPS} unixodbc-dev && \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,8 +27,8 @@ fi
 # Periodically run visit:locate every hour, if ENABLE_PERIODIC_VISIT_LOCATE=true was provided
 if [ "${ENABLE_PERIODIC_VISIT_LOCATE}" = "true" ]; then
   echo "Configuring periodic visit location..."
-  echo "0 * * * * php /etc/shlink/bin/cli visit:locate -q" > /etc/crontabs/root
-  /usr/sbin/crond &
+  echo "0 * * * * php /etc/shlink/bin/cli visit:locate -q" > /tmp/crontab
+  supercronic -passthrough-logs /tmp/crontab &
 fi
 
 # RoadRunner config needs these to have been set, so falling back to default values if not set yet


### PR DESCRIPTION
# How Shlink is setup
* Shlink version: 3.5.4
* How do you serve Shlink: Docker image

Hello there, I want to use shlink on a restrictive cluster and unfortunately I noticed that it couldn't run as non root.
https://github.com/shlinkio/shlink/issues/1132

I then noticed this issue https://github.com/shlinkio/shlink/issues/1689 and thought that I would give it a try.

I ran the test with the following docker-compose
```yaml
version: '3'

services:
    shlink:
        container_name: shlink
        ports:
          - '8080:8080'
        image: shlink-test #build locally
        user: '1000001'
        environment:
          - DEFAULT_DOMAIN=s.test
          - IS_HTTPS_ENABLED=true
          - ENALE_PERIODIC_VISIT_LOCATE=true
 ```

How the logs look with supercronic (edited cron schedule to run every minutes just for testing)
```
shlink    | [2023-04-28T12:24:24.393068+00:00] [NULL] Access.NOTICE - Worker started in /etc/shlink with ID 13
shlink    | [2023-04-28T12:24:24.393561+00:00] [NULL] Access.NOTICE - Worker started in /etc/shlink with ID 14
shlink    | [2023-04-28T12:24:24.394057+00:00] [NULL] Access.NOTICE - Worker started in /etc/shlink with ID 15
shlink    | time="2023-04-28T12:25:00Z" level=info msg=starting iteration=0 job.command="php /etc/shlink/bin/cli visit:locate -q" job.position=0 job.schedule="* * * * *"
shlink    | time="2023-04-28T12:25:00Z" level=info msg="job succeeded" iteration=0 job.command="php /etc/shlink/bin/cli visit:locate -q" job.position=0 job.schedule="* * * * *"
shlink    | time="2023-04-28T12:26:00Z" level=info msg=starting iteration=1 job.command="php /etc/shlink/bin/cli visit:locate -q" job.position=0 job.schedule="* * * * *"
```

I changed a bit the part to run it as non root, by changing the whole /etc/shlink it gives the possibility to edit php file as non-root in the docker image. By running `chmod g=u` it makes it possible to run this image as any user and not just 1001
```dockerfile
# Change the ownership of /etc/shlink to be writable, then change the user to non-root
RUN chown -R 1001 /etc/shlink
RUN chmod -R g=u /etc/shlink

USER 1001
```
