### PR TITLE
Fix short URL visits deletion when multi-segment slugs are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ### Fixed
 * [#1819](https://github.com/shlinkio/shlink/issues/1819) Fix incorrect timeout when running DB commands during Shlink start-up.
 * [#1901](https://github.com/shlinkio/shlink/issues/1901) Do not allow short URLs with custom slugs containing URL-reserved characters, as they will not work at all afterward.
+* [#1900](https://github.com/shlinkio/shlink/issues/1900) Fix short URL visits deletion when multi-segment slugs are enabled.
 
 
 ## [3.6.4] - 2023-09-23

--- a/config/autoload/routes.config.php
+++ b/config/autoload/routes.config.php
@@ -32,8 +32,11 @@ return (static function (): array {
             ...ConfigProvider::applyRoutesPrefix([
                 Action\HealthAction::getRouteDef(),
 
-                // Visits
+                // Visits.
+                // These routes must go first, as they have a more specific path, otherwise, when multi-segment slugs
+                // are enabled, routes with a less-specific path might match first
                 Action\Visit\ShortUrlVisitsAction::getRouteDef([$dropDomainMiddleware]),
+                Action\ShortUrl\DeleteShortUrlVisitsAction::getRouteDef([$dropDomainMiddleware]),
                 Action\Visit\TagVisitsAction::getRouteDef(),
                 Action\Visit\DomainVisitsAction::getRouteDef(),
                 Action\Visit\GlobalVisitsAction::getRouteDef(),
@@ -54,7 +57,6 @@ return (static function (): array {
                 ]),
                 Action\ShortUrl\EditShortUrlAction::getRouteDef([$dropDomainMiddleware]),
                 Action\ShortUrl\DeleteShortUrlAction::getRouteDef([$dropDomainMiddleware]),
-                Action\ShortUrl\DeleteShortUrlVisitsAction::getRouteDef([$dropDomainMiddleware]),
                 Action\ShortUrl\ResolveShortUrlAction::getRouteDef([$dropDomainMiddleware]),
                 Action\ShortUrl\ListShortUrlsAction::getRouteDef(),
 


### PR DESCRIPTION
Closes #1900 

Re-arrange route definitions so that short URL visits deletion matches before short URL deletion one when multi-segment slugs are enabled.