### PR TITLE
add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ First, make sure the host where you are going to run shlink fulfills these requi
     * You will also need the corresponding pdo variation for the database you are planning to use: `pdo_mysql`, `pdo_pgsql`, `pdo_sqlsrv` or `pdo_sqlite`.
 * The [openswoole](https://openswoole.com/) PHP extension (if you plan to serve Shlink with openswoole) or the web server of your choice with PHP integration (like Apache or Nginx).
 
+### Dome 
+
+Deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=shlinkio):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=shlinkio)
+
 ### Download
 
 In order to run Shlink, you will need a built version of the project. There are two ways to get it.


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://shlinkio-1-1045.dome.tools

Since the base url for **shlink** doesn't return anything, the dome.tools url will look broken in this case, but the API will work as it is supposed to. 

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.