### PR TITLE
Support loading env vars from secret files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 ### Added
-* *Nothing*
+* [#1868](https://github.com/shlinkio/shlink/issues/1868) Add support for [docker compose secrets](https://docs.docker.com/compose/use-secrets/) to the docker image.
 
 ### Changed
 * [#1935](https://github.com/shlinkio/shlink/issues/1935) Replace dependency on abandoned `php-middleware/request-id` with userland simple middleware.

--- a/bin/test/run-api-tests.sh
+++ b/bin/test/run-api-tests.sh
@@ -20,6 +20,8 @@ echo 'Starting server...'
 [ "$TEST_RUNTIME" = 'openswoole' ] && vendor/bin/laminas mezzio:swoole:start -d
 [ "$TEST_RUNTIME" = 'rr' ] && bin/rr serve -p -c=config/roadrunner/.rr.dev.yml \
   -o=http.address=0.0.0.0:9999 \
+  -o=http.pool.debug=false \
+  -o=jobs.pool.debug=false \
   -o=logs.encoding=json \
   -o=logs.channels.http.encoding=json \
   -o=logs.channels.server.encoding=json \
@@ -29,10 +31,10 @@ echo 'Starting server...'
 sleep 2 # Let's give the server a couple of seconds to start
 
 vendor/bin/phpunit --order-by=random -c phpunit-api.xml --testdox --colors=always --log-junit=build/coverage-api/junit.xml $*
-testsExitCode=$?
+TESTS_EXIT_CODE=$?
 
 [ "$TEST_RUNTIME" = 'openswoole' ] && vendor/bin/laminas mezzio:swoole:stop
 [ "$TEST_RUNTIME" = 'rr' ] && bin/rr stop -c config/roadrunner/.rr.dev.yml -o=http.address=0.0.0.0:9999
 
 # Exit this script with the same code as the tests. If tests failed, this script has to fail
-exit $testsExitCode
+exit $TESTS_EXIT_CODE

--- a/module/Core/test/Config/EnvVarsTest.php
+++ b/module/Core/test/Config/EnvVarsTest.php
@@ -17,12 +17,16 @@ class EnvVarsTest extends TestCase
     {
         putenv(EnvVars::BASE_PATH->value . '=the_base_path');
         putenv(EnvVars::DB_NAME->value . '=shlink');
+
+        $envFilePath = __DIR__ . '/../DB_PASSWORD.env';
+        putenv(EnvVars::DB_PASSWORD->value . '_FILE=' . $envFilePath);
     }
 
     protected function tearDown(): void
     {
         putenv(EnvVars::BASE_PATH->value . '=');
         putenv(EnvVars::DB_NAME->value . '=');
+        putenv(EnvVars::DB_PASSWORD->value . '_FILE=');
     }
 
     #[Test, DataProvider('provideExistingEnvVars')]
@@ -53,5 +57,11 @@ class EnvVarsTest extends TestCase
         yield 'BASE_PATH with default' => [EnvVars::BASE_PATH, 'the_base_path', 'foobar'];
         yield 'DB_DRIVER without default' => [EnvVars::DB_DRIVER, null, null];
         yield 'DB_DRIVER with default' => [EnvVars::DB_DRIVER, 'foobar', 'foobar'];
+    }
+
+    #[Test]
+    public function fallsBackToReadEnvVarsFromFile(): void
+    {
+        self::assertEquals('this_is_the_password', EnvVars::DB_PASSWORD->loadFromEnv());
     }
 }

--- a/module/Core/test/DB_PASSWORD.env
+++ b/module/Core/test/DB_PASSWORD.env
@@ -1,0 +1,1 @@
+this_is_the_password


### PR DESCRIPTION
Closes #1868 

This PR updates how environment variables are read, so that, if the actual env var is not found, it tries to read the equivalent env var but with the `_FILE` suffix.

This way, if for example, `DB_PASSWORD` is not set, but `DB_PASSWORD_FILE` is, we treat the value as a file path, read it, and return its contents as the `DB_PASSWORD` value.

Regular env vars will always take precedence, so if both `DB_PASSWORD` and `DB_PASSWORD_FILE` are set, the latter will be ignored.

