### PR TITLE
Support filtering orphan visits by type in VisitRepository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ## [Unreleased]
 ### Added
 * [#1868](https://github.com/shlinkio/shlink/issues/1868) Add support for [docker compose secrets](https://docs.docker.com/compose/use-secrets/) to the docker image.
+* [#1979](https://github.com/shlinkio/shlink/issues/1979) Allow orphan visits lists to be filtered by type.
+
+  This is supported both by the `GET /visits/orphan` API endpoint via `type=...` query param, and by the `visit:orphan` CLI command, via `--type` flag.
 
 ### Changed
 * [#1935](https://github.com/shlinkio/shlink/issues/1935) Replace dependency on abandoned `php-middleware/request-id` with userland simple middleware.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
 
     shlink_swagger_ui:
         container_name: shlink_swagger_ui
-        image: swaggerapi/swagger-ui:v5.10.3
+        image: swaggerapi/swagger-ui:v5.11.3
         ports:
             - "8005:8080"
         volumes:

--- a/docs/swagger/paths/v2_visits_orphan.json
+++ b/docs/swagger/paths/v2_visits_orphan.json
@@ -55,6 +55,16 @@
                     "type": "string",
                     "enum": ["true"]
                 }
+            },
+            {
+                "name": "type",
+                "in": "query",
+                "description": "The type of visits to return. All visits are returned when not provided.",
+                "required": false,
+                "schema": {
+                    "type": "string",
+                    "enum": ["invalid_short_url", "base_url", "regular_404"]
+                }
             }
         ],
         "security": [
@@ -131,6 +141,54 @@
                                     "itemsPerPage": 10,
                                     "itemsInCurrentPage": 10,
                                     "totalItems": 115
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "400": {
+                "description": "Provided query arguments are invalid.",
+                "content": {
+                    "application/problem+json": {
+                        "schema": {
+                            "type": "object",
+                            "allOf": [
+                                {
+                                    "$ref": "../definitions/Error.json"
+                                },
+                                {
+                                    "type": "object",
+                                    "required": ["invalidElements"],
+                                    "properties": {
+                                        "invalidElements": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": ["type"]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "examples": {
+                            "API v3 and newer": {
+                                "value": {
+                                    "title": "Invalid data",
+                                    "type": "https://shlink.io/api/error/invalid-data",
+                                    "detail": "Provided data is not valid",
+                                    "status": 400,
+                                    "invalidElements": ["type"]
+                                }
+                            },
+                            "Previous to API v3": {
+                                "value": {
+                                    "title": "Invalid data",
+                                    "type": "INVALID_ARGUMENT",
+                                    "detail": "Provided data is not valid",
+                                    "status": 400,
+                                    "invalidElements": ["type"]
                                 }
                             }
                         }

--- a/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
@@ -7,7 +7,7 @@ namespace Shlinkio\Shlink\CLI\Command\Visit;
 use Shlinkio\Shlink\Common\Paginator\Paginator;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
-use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Symfony\Component\Console\Input\InputInterface;
 
 class GetOrphanVisitsCommand extends AbstractVisitsListCommand
@@ -23,7 +23,7 @@ class GetOrphanVisitsCommand extends AbstractVisitsListCommand
 
     protected function getVisitsPaginator(InputInterface $input, DateRange $dateRange): Paginator
     {
-        return $this->visitsHelper->orphanVisits(new VisitsParams($dateRange));
+        return $this->visitsHelper->orphanVisits(new OrphanVisitsParams($dateRange));
     }
 
     /**

--- a/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
@@ -8,7 +8,12 @@ use Shlinkio\Shlink\Common\Paginator\Paginator;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
 use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitType;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+use function Shlinkio\Shlink\Core\enumToString;
+use function sprintf;
 
 class GetOrphanVisitsCommand extends AbstractVisitsListCommand
 {
@@ -18,12 +23,18 @@ class GetOrphanVisitsCommand extends AbstractVisitsListCommand
     {
         $this
             ->setName(self::NAME)
-            ->setDescription('Returns the list of orphan visits.');
+            ->setDescription('Returns the list of orphan visits.')
+            ->addOption('type', 't', InputOption::VALUE_REQUIRED, sprintf(
+                'Return visits only with this type. One of %s',
+                enumToString(OrphanVisitType::class),
+            ));
     }
 
     protected function getVisitsPaginator(InputInterface $input, DateRange $dateRange): Paginator
     {
-        return $this->visitsHelper->orphanVisits(new OrphanVisitsParams($dateRange));
+        $rawType = $input->getOption('type');
+        $type = $rawType !== null ? OrphanVisitType::from($rawType) : null;
+        return $this->visitsHelper->orphanVisits(new OrphanVisitsParams(dateRange: $dateRange, type: $type));
     }
 
     /**

--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -20,6 +20,7 @@ use function array_keys;
 use function array_map;
 use function array_reduce;
 use function date_default_timezone_get;
+use function implode;
 use function is_array;
 use function print_r;
 use function Shlinkio\Shlink\Common\buildDateRange;
@@ -181,4 +182,12 @@ function enumValues(string $enum): array
     return $cache[$enum] ?? (
         $cache[$enum] = array_map(static fn (BackedEnum $type) => (string) $type->value, $enum::cases())
     );
+}
+
+/**
+ * @param class-string<BackedEnum> $enum
+ */
+function enumToString(string $enum): string
+{
+    return sprintf('["%s"]', implode('", "', enumValues($enum)));
 }

--- a/module/Core/src/Visit/Model/OrphanVisitType.php
+++ b/module/Core/src/Visit/Model/OrphanVisitType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Visit\Model;
+
+enum OrphanVisitType: string
+{
+    case INVALID_SHORT_URL = 'invalid_short_url';
+    case BASE_URL = 'base_url';
+    case REGULAR_404 = 'regular_404';
+}

--- a/module/Core/src/Visit/Model/OrphanVisitsParams.php
+++ b/module/Core/src/Visit/Model/OrphanVisitsParams.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\Visit\Model;
+
+use Shlinkio\Shlink\Common\Util\DateRange;
+use Shlinkio\Shlink\Core\Exception\ValidationException;
+use ValueError;
+
+use function implode;
+use function Shlinkio\Shlink\Core\enumValues;
+use function sprintf;
+
+final class OrphanVisitsParams extends VisitsParams
+{
+    public function __construct(
+        ?DateRange $dateRange = null,
+        ?int $page = null,
+        ?int $itemsPerPage = null,
+        bool $excludeBots = false,
+        public readonly ?OrphanVisitType $type = null,
+    ) {
+        parent::__construct($dateRange, $page, $itemsPerPage, $excludeBots);
+    }
+
+    public static function fromRawData(array $query): self
+    {
+        $visitsParams = parent::fromRawData($query);
+        $type = $query['type'] ?? null;
+
+        return new self(
+            dateRange: $visitsParams->dateRange,
+            page: $visitsParams->page,
+            itemsPerPage: $visitsParams->itemsPerPage,
+            excludeBots: $visitsParams->excludeBots,
+            type: $type !== null ? self::parseType($type) : null,
+        );
+    }
+
+    private static function parseType(string $type): OrphanVisitType
+    {
+        try {
+            return OrphanVisitType::from($type);
+        } catch (ValueError) {
+            throw ValidationException::fromArray([
+                'type' => sprintf(
+                    '%s is not a valid orphan visit type. Expected one of ["%s"]',
+                    $type,
+                    implode('", "', enumValues(OrphanVisitType::class)),
+                ),
+            ]);
+        }
+    }
+}

--- a/module/Core/src/Visit/Model/OrphanVisitsParams.php
+++ b/module/Core/src/Visit/Model/OrphanVisitsParams.php
@@ -6,8 +6,7 @@ use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\Exception\ValidationException;
 use ValueError;
 
-use function implode;
-use function Shlinkio\Shlink\Core\enumValues;
+use function Shlinkio\Shlink\Core\enumToString;
 use function sprintf;
 
 final class OrphanVisitsParams extends VisitsParams
@@ -43,9 +42,9 @@ final class OrphanVisitsParams extends VisitsParams
         } catch (ValueError) {
             throw ValidationException::fromArray([
                 'type' => sprintf(
-                    '%s is not a valid orphan visit type. Expected one of ["%s"]',
+                    '%s is not a valid orphan visit type. Expected one of %s',
                     $type,
-                    implode('", "', enumValues(OrphanVisitType::class)),
+                    enumToString(OrphanVisitType::class),
                 ),
             ]);
         }

--- a/module/Core/src/Visit/Model/VisitType.php
+++ b/module/Core/src/Visit/Model/VisitType.php
@@ -8,7 +8,7 @@ enum VisitType: string
 {
     case VALID_SHORT_URL = 'valid_short_url';
     case IMPORTED = 'imported';
-    case INVALID_SHORT_URL = 'invalid_short_url';
-    case BASE_URL = 'base_url';
-    case REGULAR_404 = 'regular_404';
+    case INVALID_SHORT_URL = OrphanVisitType::INVALID_SHORT_URL->value;
+    case BASE_URL = OrphanVisitType::BASE_URL->value;
+    case REGULAR_404 = OrphanVisitType::REGULAR_404->value;
 }

--- a/module/Core/src/Visit/Model/VisitsParams.php
+++ b/module/Core/src/Visit/Model/VisitsParams.php
@@ -9,7 +9,7 @@ use Shlinkio\Shlink\Core\Model\AbstractInfinitePaginableListParams;
 
 use function Shlinkio\Shlink\Core\parseDateRangeFromQuery;
 
-final class VisitsParams extends AbstractInfinitePaginableListParams
+class VisitsParams extends AbstractInfinitePaginableListParams
 {
     public readonly DateRange $dateRange;
 

--- a/module/Core/src/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapter.php
+++ b/module/Core/src/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\Core\Visit\Paginator\Adapter;
 
 use Shlinkio\Shlink\Core\Paginator\Adapter\AbstractCacheableCountPaginatorAdapter;
-use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepositoryInterface;
@@ -15,7 +15,7 @@ class OrphanVisitsPaginatorAdapter extends AbstractCacheableCountPaginatorAdapte
 {
     public function __construct(
         private readonly VisitRepositoryInterface $repo,
-        private readonly VisitsParams $params,
+        private readonly OrphanVisitsParams $params,
         private readonly ?ApiKey $apiKey,
     ) {
     }
@@ -26,6 +26,7 @@ class OrphanVisitsPaginatorAdapter extends AbstractCacheableCountPaginatorAdapte
             dateRange: $this->params->dateRange,
             excludeBots: $this->params->excludeBots,
             apiKey: $this->apiKey,
+            type: $this->params->type,
         ));
     }
 
@@ -35,6 +36,7 @@ class OrphanVisitsPaginatorAdapter extends AbstractCacheableCountPaginatorAdapte
             dateRange: $this->params->dateRange,
             excludeBots: $this->params->excludeBots,
             apiKey: $this->apiKey,
+            type: $this->params->type,
             limit: $length,
             offset: $offset,
         ));

--- a/module/Core/src/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapter.php
+++ b/module/Core/src/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapter.php
@@ -6,8 +6,8 @@ namespace Shlinkio\Shlink\Core\Visit\Paginator\Adapter;
 
 use Shlinkio\Shlink\Core\Paginator\Adapter\AbstractCacheableCountPaginatorAdapter;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
-use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
-use Shlinkio\Shlink\Core\Visit\Persistence\VisitsListFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepositoryInterface;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
@@ -22,7 +22,7 @@ class OrphanVisitsPaginatorAdapter extends AbstractCacheableCountPaginatorAdapte
 
     protected function doCount(): int
     {
-        return $this->repo->countOrphanVisits(new VisitsCountFiltering(
+        return $this->repo->countOrphanVisits(new OrphanVisitsCountFiltering(
             dateRange: $this->params->dateRange,
             excludeBots: $this->params->excludeBots,
             apiKey: $this->apiKey,
@@ -31,7 +31,7 @@ class OrphanVisitsPaginatorAdapter extends AbstractCacheableCountPaginatorAdapte
 
     public function getSlice(int $offset, int $length): iterable
     {
-        return $this->repo->findOrphanVisits(new VisitsListFiltering(
+        return $this->repo->findOrphanVisits(new OrphanVisitsListFiltering(
             dateRange: $this->params->dateRange,
             excludeBots: $this->params->excludeBots,
             apiKey: $this->apiKey,

--- a/module/Core/src/Visit/Persistence/OrphanVisitsCountFiltering.php
+++ b/module/Core/src/Visit/Persistence/OrphanVisitsCountFiltering.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Visit\Persistence;
+
+use Shlinkio\Shlink\Common\Util\DateRange;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitType;
+use Shlinkio\Shlink\Rest\Entity\ApiKey;
+
+class OrphanVisitsCountFiltering extends VisitsCountFiltering
+{
+    public function __construct(
+        ?DateRange $dateRange = null,
+        bool $excludeBots = false,
+        ?ApiKey $apiKey = null,
+        public readonly ?OrphanVisitType $type = null,
+    ) {
+        parent::__construct($dateRange, $excludeBots, $apiKey);
+    }
+}

--- a/module/Core/src/Visit/Persistence/OrphanVisitsListFiltering.php
+++ b/module/Core/src/Visit/Persistence/OrphanVisitsListFiltering.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Visit\Persistence;
+
+use Shlinkio\Shlink\Common\Util\DateRange;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitType;
+use Shlinkio\Shlink\Rest\Entity\ApiKey;
+
+final class OrphanVisitsListFiltering extends OrphanVisitsCountFiltering
+{
+    public function __construct(
+        ?DateRange $dateRange = null,
+        bool $excludeBots = false,
+        ?ApiKey $apiKey = null,
+        ?OrphanVisitType $type = null,
+        public readonly ?int $limit = null,
+        public readonly ?int $offset = null,
+    ) {
+        parent::__construct($dateRange, $excludeBots, $apiKey, $type);
+    }
+}

--- a/module/Core/src/Visit/Persistence/VisitsCountFiltering.php
+++ b/module/Core/src/Visit/Persistence/VisitsCountFiltering.php
@@ -15,9 +15,4 @@ class VisitsCountFiltering
         public readonly ?ApiKey $apiKey = null,
     ) {
     }
-
-    public static function withApiKey(?ApiKey $apiKey): self
-    {
-        return new self(apiKey: $apiKey);
-    }
 }

--- a/module/Core/src/Visit/Repository/VisitRepositoryInterface.php
+++ b/module/Core/src/Visit/Repository/VisitRepositoryInterface.php
@@ -8,6 +8,8 @@ use Doctrine\Persistence\ObjectRepository;
 use Happyr\DoctrineSpecification\Repository\EntitySpecificationRepositoryInterface;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\VisitsListFiltering;
 
@@ -37,9 +39,9 @@ interface VisitRepositoryInterface extends ObjectRepository, EntitySpecification
     /**
      * @return Visit[]
      */
-    public function findOrphanVisits(VisitsListFiltering $filtering): array;
+    public function findOrphanVisits(OrphanVisitsListFiltering $filtering): array;
 
-    public function countOrphanVisits(VisitsCountFiltering $filtering): int;
+    public function countOrphanVisits(OrphanVisitsCountFiltering $filtering): int;
 
     /**
      * @return Visit[]

--- a/module/Core/src/Visit/Spec/CountOfOrphanVisits.php
+++ b/module/Core/src/Visit/Spec/CountOfOrphanVisits.php
@@ -8,11 +8,11 @@ use Happyr\DoctrineSpecification\Spec;
 use Happyr\DoctrineSpecification\Specification\BaseSpecification;
 use Happyr\DoctrineSpecification\Specification\Specification;
 use Shlinkio\Shlink\Core\Spec\InDateRange;
-use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
 
 class CountOfOrphanVisits extends BaseSpecification
 {
-    public function __construct(private VisitsCountFiltering $filtering)
+    public function __construct(private readonly OrphanVisitsCountFiltering $filtering)
     {
         parent::__construct();
     }
@@ -26,6 +26,10 @@ class CountOfOrphanVisits extends BaseSpecification
 
         if ($this->filtering->excludeBots) {
             $conditions[] = Spec::eq('potentialBot', false);
+        }
+
+        if ($this->filtering->type) {
+            $conditions[] = Spec::eq('type', $this->filtering->type->value);
         }
 
         return Spec::countOf(Spec::andX(...$conditions));

--- a/module/Core/src/Visit/VisitsStatsHelper.php
+++ b/module/Core/src/Visit/VisitsStatsHelper.php
@@ -25,6 +25,7 @@ use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\NonOrphanVisitsPaginatorAdapter
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\OrphanVisitsPaginatorAdapter;
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\ShortUrlVisitsPaginatorAdapter;
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\TagVisitsPaginatorAdapter;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepository;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepositoryInterface;
@@ -42,13 +43,13 @@ class VisitsStatsHelper implements VisitsStatsHelperInterface
         $visitsRepo = $this->em->getRepository(Visit::class);
 
         return new VisitsStats(
-            nonOrphanVisitsTotal: $visitsRepo->countNonOrphanVisits(VisitsCountFiltering::withApiKey($apiKey)),
-            orphanVisitsTotal: $visitsRepo->countOrphanVisits(VisitsCountFiltering::withApiKey($apiKey)),
+            nonOrphanVisitsTotal: $visitsRepo->countNonOrphanVisits(new VisitsCountFiltering(apiKey: $apiKey)),
+            orphanVisitsTotal: $visitsRepo->countOrphanVisits(new OrphanVisitsCountFiltering(apiKey: $apiKey)),
             nonOrphanVisitsNonBots: $visitsRepo->countNonOrphanVisits(
                 new VisitsCountFiltering(excludeBots: true, apiKey: $apiKey),
             ),
             orphanVisitsNonBots: $visitsRepo->countOrphanVisits(
-                new VisitsCountFiltering(excludeBots: true, apiKey: $apiKey),
+                new OrphanVisitsCountFiltering(excludeBots: true, apiKey: $apiKey),
             ),
         );
     }

--- a/module/Core/src/Visit/VisitsStatsHelper.php
+++ b/module/Core/src/Visit/VisitsStatsHelper.php
@@ -18,6 +18,7 @@ use Shlinkio\Shlink\Core\ShortUrl\Repository\ShortUrlRepositoryInterface;
 use Shlinkio\Shlink\Core\Tag\Entity\Tag;
 use Shlinkio\Shlink\Core\Tag\Repository\TagRepository;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsStats;
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\DomainVisitsPaginatorAdapter;
@@ -117,7 +118,7 @@ class VisitsStatsHelper implements VisitsStatsHelperInterface
     /**
      * @return Visit[]|Paginator
      */
-    public function orphanVisits(VisitsParams $params, ?ApiKey $apiKey = null): Paginator
+    public function orphanVisits(OrphanVisitsParams $params, ?ApiKey $apiKey = null): Paginator
     {
         /** @var VisitRepositoryInterface $repo */
         $repo = $this->em->getRepository(Visit::class);

--- a/module/Core/src/Visit/VisitsStatsHelperInterface.php
+++ b/module/Core/src/Visit/VisitsStatsHelperInterface.php
@@ -10,6 +10,7 @@ use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
 use Shlinkio\Shlink\Core\Exception\TagNotFoundException;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsStats;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
@@ -43,7 +44,7 @@ interface VisitsStatsHelperInterface
     /**
      * @return Visit[]|Paginator
      */
-    public function orphanVisits(VisitsParams $params, ?ApiKey $apiKey = null): Paginator;
+    public function orphanVisits(OrphanVisitsParams $params, ?ApiKey $apiKey = null): Paginator;
 
     /**
      * @return Visit[]|Paginator

--- a/module/Core/test/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapterTest.php
+++ b/module/Core/test/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapterTest.php
@@ -12,8 +12,8 @@ use Shlinkio\Shlink\Core\Visit\Entity\Visit;
 use Shlinkio\Shlink\Core\Visit\Model\Visitor;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\OrphanVisitsPaginatorAdapter;
-use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
-use Shlinkio\Shlink\Core\Visit\Persistence\VisitsListFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepositoryInterface;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
@@ -38,7 +38,7 @@ class OrphanVisitsPaginatorAdapterTest extends TestCase
     {
         $expectedCount = 5;
         $this->repo->expects($this->once())->method('countOrphanVisits')->with(
-            new VisitsCountFiltering($this->params->dateRange, apiKey: $this->apiKey),
+            new OrphanVisitsCountFiltering($this->params->dateRange, apiKey: $this->apiKey),
         )->willReturn($expectedCount);
 
         $result = $this->adapter->getNbResults();
@@ -55,12 +55,12 @@ class OrphanVisitsPaginatorAdapterTest extends TestCase
     {
         $visitor = Visitor::emptyInstance();
         $list = [Visit::forRegularNotFound($visitor), Visit::forInvalidShortUrl($visitor)];
-        $this->repo->expects($this->once())->method('findOrphanVisits')->with(new VisitsListFiltering(
-            $this->params->dateRange,
-            $this->params->excludeBots,
-            $this->apiKey,
-            $limit,
-            $offset,
+        $this->repo->expects($this->once())->method('findOrphanVisits')->with(new OrphanVisitsListFiltering(
+            dateRange: $this->params->dateRange,
+            excludeBots: $this->params->excludeBots,
+            apiKey: $this->apiKey,
+            limit: $limit,
+            offset: $offset,
         ))->willReturn($list);
 
         $result = $this->adapter->getSlice($offset, $limit);

--- a/module/Core/test/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapterTest.php
+++ b/module/Core/test/Visit/Paginator/Adapter/OrphanVisitsPaginatorAdapterTest.php
@@ -9,8 +9,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\Visitor;
-use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Paginator\Adapter\OrphanVisitsPaginatorAdapter;
 use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
@@ -21,13 +21,13 @@ class OrphanVisitsPaginatorAdapterTest extends TestCase
 {
     private OrphanVisitsPaginatorAdapter $adapter;
     private MockObject & VisitRepositoryInterface $repo;
-    private VisitsParams $params;
+    private OrphanVisitsParams $params;
     private ApiKey $apiKey;
 
     protected function setUp(): void
     {
         $this->repo = $this->createMock(VisitRepositoryInterface::class);
-        $this->params = VisitsParams::fromRawData([]);
+        $this->params = OrphanVisitsParams::fromRawData([]);
         $this->apiKey = ApiKey::create();
 
         $this->adapter = new OrphanVisitsPaginatorAdapter($this->repo, $this->params, $this->apiKey);

--- a/module/Core/test/Visit/VisitsStatsHelperTest.php
+++ b/module/Core/test/Visit/VisitsStatsHelperTest.php
@@ -26,6 +26,8 @@ use Shlinkio\Shlink\Core\Visit\Entity\Visit;
 use Shlinkio\Shlink\Core\Visit\Model\Visitor;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsStats;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsCountFiltering;
+use Shlinkio\Shlink\Core\Visit\Persistence\OrphanVisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\VisitsCountFiltering;
 use Shlinkio\Shlink\Core\Visit\Persistence\VisitsListFiltering;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitRepository;
@@ -251,10 +253,10 @@ class VisitsStatsHelperTest extends TestCase
         $list = array_map(static fn () => Visit::forBasePath(Visitor::emptyInstance()), range(0, 3));
         $repo = $this->createMock(VisitRepository::class);
         $repo->expects($this->once())->method('countOrphanVisits')->with(
-            $this->isInstanceOf(VisitsCountFiltering::class),
+            $this->isInstanceOf(OrphanVisitsCountFiltering::class),
         )->willReturn(count($list));
         $repo->expects($this->once())->method('findOrphanVisits')->with(
-            $this->isInstanceOf(VisitsListFiltering::class),
+            $this->isInstanceOf(OrphanVisitsListFiltering::class),
         )->willReturn($list);
         $this->em->expects($this->once())->method('getRepository')->with(Visit::class)->willReturn($repo);
 

--- a/module/Core/test/Visit/VisitsStatsHelperTest.php
+++ b/module/Core/test/Visit/VisitsStatsHelperTest.php
@@ -23,6 +23,7 @@ use Shlinkio\Shlink\Core\ShortUrl\Repository\ShortUrlRepositoryInterface;
 use Shlinkio\Shlink\Core\Tag\Entity\Tag;
 use Shlinkio\Shlink\Core\Tag\Repository\TagRepository;
 use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\Visitor;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsStats;
@@ -260,7 +261,7 @@ class VisitsStatsHelperTest extends TestCase
         )->willReturn($list);
         $this->em->expects($this->once())->method('getRepository')->with(Visit::class)->willReturn($repo);
 
-        $paginator = $this->helper->orphanVisits(new VisitsParams());
+        $paginator = $this->helper->orphanVisits(new OrphanVisitsParams());
 
         self::assertEquals($list, ArrayUtils::iteratorToArray($paginator->getCurrentPageResults()));
     }

--- a/module/Rest/src/Action/Visit/OrphanVisitsAction.php
+++ b/module/Rest/src/Action/Visit/OrphanVisitsAction.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Common\Paginator\Util\PagerfantaUtilsTrait;
 use Shlinkio\Shlink\Common\Rest\DataTransformerInterface;
-use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitsParams;
 use Shlinkio\Shlink\Core\Visit\VisitsStatsHelperInterface;
 use Shlinkio\Shlink\Rest\Action\AbstractRestAction;
 use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
@@ -29,7 +29,7 @@ class OrphanVisitsAction extends AbstractRestAction
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $params = VisitsParams::fromRawData($request->getQueryParams());
+        $params = OrphanVisitsParams::fromRawData($request->getQueryParams());
         $apiKey = AuthenticationMiddleware::apiKeyFromRequest($request);
         $visits = $this->visitsHelper->orphanVisits($params, $apiKey);
 

--- a/module/Rest/test-api/Action/OrphanVisitsTest.php
+++ b/module/Rest/test-api/Action/OrphanVisitsTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Shlinkio\Shlink\Common\Paginator\Paginator;
+use Shlinkio\Shlink\Core\Visit\Model\OrphanVisitType;
 use Shlinkio\Shlink\TestUtils\ApiTest\ApiTestCase;
 
 class OrphanVisitsTest extends ApiTestCase
@@ -68,6 +69,23 @@ class OrphanVisitsTest extends ApiTestCase
             1,
             [self::REGULAR_NOT_FOUND],
         ];
+        yield 'base_url only' => [['type' => OrphanVisitType::BASE_URL->value], 1, 1, [self::BASE_URL]];
+        yield 'regular_404 only' => [['type' => OrphanVisitType::REGULAR_404->value], 1, 1, [self::REGULAR_NOT_FOUND]];
+        yield 'invalid_short_url only' => [
+            ['type' => OrphanVisitType::INVALID_SHORT_URL->value],
+            1,
+            1,
+            [self::INVALID_SHORT_URL],
+        ];
+    }
+
+    #[Test]
+    public function errorIsReturnedForInvalidType(): void
+    {
+        $resp = $this->callApiWithKey(self::METHOD_GET, '/visits/orphan', [
+            RequestOptions::QUERY => ['type' => 'invalid'],
+        ]);
+        self::assertEquals(400, $resp->getStatusCode());
     }
 
     #[Test]


### PR DESCRIPTION
Closes #1979 

Shlink-web-client has supported filtering orphan visits by type for some time, but this was always done client-side.

This PR adds the ability to filter orphan visits lists by `type`, both via REST API and CLI.