### PR TITLE
Change long URL columns to TEXT type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * [#1786](https://github.com/shlinkio/shlink/issues/1786) Run API tests with RoadRunner by default.
 * [#2008](https://github.com/shlinkio/shlink/issues/2008) Update to Doctrine ORM 3.0.
 * [#2010](https://github.com/shlinkio/shlink/issues/2010) Update to Symfony 7.0 components.
-* [#2016](https://github.com/shlinkio/shlink/issues/2016) Simplify and improve how code coverage is generated in API and CLI tests".
+* [#2016](https://github.com/shlinkio/shlink/issues/2016) Simplify and improve how code coverage is generated in API and CLI tests.
+* [#1674](https://github.com/shlinkio/shlink/issues/1674) Database columns persisting long URLs have now `TEXT` type, which allows for much longer values.
 
 ### Deprecated
 * *Nothing*

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
@@ -25,17 +25,17 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->unique()
             ->build();
 
-    fieldWithUtf8Charset($builder->createField('baseUrlRedirect', Types::STRING), $emConfig)
+    fieldWithUtf8Charset($builder->createField('baseUrlRedirect', Types::TEXT), $emConfig)
             ->columnName('base_url_redirect')
             ->nullable()
             ->build();
 
-    fieldWithUtf8Charset($builder->createField('regular404Redirect', Types::STRING), $emConfig)
+    fieldWithUtf8Charset($builder->createField('regular404Redirect', Types::TEXT), $emConfig)
             ->columnName('regular_not_found_redirect')
             ->nullable()
             ->build();
 
-    fieldWithUtf8Charset($builder->createField('invalidShortUrlRedirect', Types::STRING), $emConfig)
+    fieldWithUtf8Charset($builder->createField('invalidShortUrlRedirect', Types::TEXT), $emConfig)
             ->columnName('invalid_short_url_redirect')
             ->nullable()
             ->build();

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.DeviceLongUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.DeviceLongUrl.php
@@ -30,9 +30,8 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
        ->length(255)
        ->build();
 
-    fieldWithUtf8Charset($builder->createField('longUrl', Types::STRING), $emConfig)
+    fieldWithUtf8Charset($builder->createField('longUrl', Types::TEXT), $emConfig)
         ->columnName('long_url')
-        ->length(2048)
         ->build();
 
     $builder->createManyToOne('shortUrl', ShortUrl\Entity\ShortUrl::class)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
@@ -23,9 +23,8 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->option('unsigned', true)
             ->build();
 
-    fieldWithUtf8Charset($builder->createField('longUrl', Types::STRING), $emConfig)
+    fieldWithUtf8Charset($builder->createField('longUrl', Types::TEXT), $emConfig)
             ->columnName('original_url') // Rename to long_url some day? ¯\_(ツ)_/¯
-            ->length(2048)
             ->build();
 
     fieldWithUtf8Charset($builder->createField('shortCode', Types::STRING), $emConfig, 'bin')

--- a/module/Core/migrations/Version20240220214031.php
+++ b/module/Core/migrations/Version20240220214031.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkMigrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240220214031 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+
+    }
+
+    public function down(Schema $schema): void
+    {
+
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! ($this->connection->getDatabasePlatform() instanceof MySQLPlatform);
+    }
+}

--- a/module/Core/migrations/Version20240220214031.php
+++ b/module/Core/migrations/Version20240220214031.php
@@ -6,18 +6,47 @@ namespace ShlinkMigrations;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
+
+use function in_array;
 
 final class Version20240220214031 extends AbstractMigration
 {
+    private const DOMAINS_COLUMNS = ['base_url_redirect', 'regular_not_found_redirect', 'invalid_short_url_redirect'];
+    private const TEXT_COLUMNS = [
+        'domains' => self::DOMAINS_COLUMNS,
+        'device_long_urls' => ['long_url'],
+        'short_urls' => ['original_url'],
+    ];
+
     public function up(Schema $schema): void
     {
+        $textType = Type::getType(Types::TEXT);
 
+        foreach (self::TEXT_COLUMNS as $table => $columns) {
+            $t = $schema->getTable($table);
+
+            foreach ($columns as $column) {
+                $c = $t->getColumn($column);
+
+                if ($c->getType() === $textType) {
+                    continue;
+                }
+
+                if (in_array($column, self::DOMAINS_COLUMNS, true)) {
+                    // Domain columns had an incorrect length
+                    $t->modifyColumn($column, ['length' => 2048]);
+                }
+                $c->setType($textType);
+            }
+        }
     }
 
     public function down(Schema $schema): void
     {
-
+        // Can't revert from TEXT to STRING, as it's bigger
     }
 
     public function isTransactional(): bool


### PR DESCRIPTION
Closes #1674 

Change long URL columns to `TEXT` type, so that much bigger values are allowed.

Affected columns are `short_urls.original_url`, `device_long_urls.long_url`, `domains.base_url_redirect`, `domains.regular_not_found_redirect` and `domains.invalid_short_url_redirect`.