### PR TITLE
Create migration for new rules and conditions tables

### DIFF
--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
@@ -28,15 +28,18 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
     fieldWithUtf8Charset($builder->createField('baseUrlRedirect', Types::TEXT), $emConfig)
             ->columnName('base_url_redirect')
             ->nullable()
+            ->length(2048)
             ->build();
 
     fieldWithUtf8Charset($builder->createField('regular404Redirect', Types::TEXT), $emConfig)
             ->columnName('regular_not_found_redirect')
             ->nullable()
+            ->length(2048)
             ->build();
 
     fieldWithUtf8Charset($builder->createField('invalidShortUrlRedirect', Types::TEXT), $emConfig)
             ->columnName('invalid_short_url_redirect')
             ->nullable()
+            ->length(2048)
             ->build();
 };

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
+use Doctrine\ORM\Mapping\Builder\FieldBuilder;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
+
+return static function (ClassMetadata $metadata, array $emConfig): void {
+    $builder = new ClassMetadataBuilder($metadata);
+
+    $builder->setTable(determineTableName('redirect_conditions', $emConfig));
+
+    $builder->createField('id', Types::BIGINT)
+            ->columnName('id')
+            ->makePrimaryKey()
+            ->generatedValue('IDENTITY')
+            ->option('unsigned', true)
+            ->build();
+
+    fieldWithUtf8Charset($builder->createField('name', Types::STRING), $emConfig)
+        ->columnName('name')
+        ->length(512)
+        ->build();
+
+    $builder->addUniqueConstraint(['name'], 'UQ_name');
+
+    (new FieldBuilder($builder, [
+        'fieldName' => 'type',
+        'type' => Types::STRING,
+        'enumType' => RedirectConditionType::class,
+    ]))->columnName('type')
+       ->length(255)
+       ->build();
+
+    fieldWithUtf8Charset($builder->createField('matchKey', Types::STRING), $emConfig)
+        ->columnName('match_key')
+        ->length(512)
+        ->nullable()
+        ->build();
+
+    fieldWithUtf8Charset($builder->createField('matchValue', Types::STRING), $emConfig)
+        ->columnName('match_value')
+        ->length(512)
+        ->build();
+};

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
@@ -37,5 +37,6 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->setJoinTable(determineTableName('redirect_conditions_in_short_url_redirect_rules', $emConfig))
             ->addInverseJoinColumn('redirect_condition_id', 'id', onDelete: 'CASCADE')
             ->addJoinColumn('short_url_redirect_rule_id', 'id', onDelete: 'CASCADE')
+            ->fetchEager() // Always fetch the corresponding conditions when loading a rule
             ->build();
 };

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
@@ -30,7 +30,7 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
         ->build();
 
     $builder->createManyToOne('shortUrl', ShortUrl\Entity\ShortUrl::class)
-            ->addJoinColumn('short_url_id', 'id', false, false, 'CASCADE')
+            ->addJoinColumn('short_url_id', 'id', nullable: false, onDelete: 'CASCADE')
             ->build();
 
     $builder->createManyToMany('conditions', RedirectRule\Entity\RedirectCondition::class)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
@@ -6,14 +6,12 @@ namespace Shlinkio\Shlink\Core;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder;
-use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Shlinkio\Shlink\Core\Model\DeviceType;
 
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('device_long_urls', $emConfig));
+    $builder->setTable(determineTableName('short_url_redirect_rules', $emConfig));
 
     $builder->createField('id', Types::BIGINT)
             ->columnName('id')
@@ -22,13 +20,9 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->option('unsigned', true)
             ->build();
 
-    (new FieldBuilder($builder, [
-        'fieldName' => 'deviceType',
-        'type' => Types::STRING,
-        'enumType' => DeviceType::class,
-    ]))->columnName('device_type')
-       ->length(255)
-       ->build();
+    $builder->createField('priority', Types::INTEGER)
+            ->columnName('priority')
+            ->build();
 
     fieldWithUtf8Charset($builder->createField('longUrl', Types::TEXT), $emConfig)
         ->columnName('long_url')
@@ -37,5 +31,11 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
 
     $builder->createManyToOne('shortUrl', ShortUrl\Entity\ShortUrl::class)
             ->addJoinColumn('short_url_id', 'id', false, false, 'CASCADE')
+            ->build();
+
+    $builder->createManyToMany('conditions', RedirectRule\Entity\RedirectCondition::class)
+            ->setJoinTable(determineTableName('redirect_conditions_in_short_url_redirect_rules', $emConfig))
+            ->addInverseJoinColumn('redirect_condition_id', 'id', onDelete: 'CASCADE')
+            ->addJoinColumn('short_url_redirect_rule_id', 'id', onDelete: 'CASCADE')
             ->build();
 };

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.DeviceLongUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.DeviceLongUrl.php
@@ -36,6 +36,6 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
         ->build();
 
     $builder->createManyToOne('shortUrl', ShortUrl\Entity\ShortUrl::class)
-            ->addJoinColumn('short_url_id', 'id', false, false, 'CASCADE')
+            ->addJoinColumn('short_url_id', 'id', nullable: false, onDelete: 'CASCADE')
             ->build();
 };

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
@@ -25,6 +25,7 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
 
     fieldWithUtf8Charset($builder->createField('longUrl', Types::TEXT), $emConfig)
             ->columnName('original_url') // Rename to long_url some day? ¯\_(ツ)_/¯
+            ->length(2048)
             ->build();
 
     fieldWithUtf8Charset($builder->createField('shortCode', Types::STRING), $emConfig, 'bin')

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
@@ -76,18 +76,18 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
 
     $builder->createManyToMany('tags', Tag\Entity\Tag::class)
             ->setJoinTable(determineTableName('short_urls_in_tags', $emConfig))
-            ->addInverseJoinColumn('tag_id', 'id', true, false, 'CASCADE')
-            ->addJoinColumn('short_url_id', 'id', true, false, 'CASCADE')
+            ->addInverseJoinColumn('tag_id', 'id', onDelete: 'CASCADE')
+            ->addJoinColumn('short_url_id', 'id', onDelete: 'CASCADE')
             ->setOrderBy(['name' => 'ASC'])
             ->build();
 
     $builder->createManyToOne('domain', Domain\Entity\Domain::class)
-            ->addJoinColumn('domain_id', 'id', true, false, 'RESTRICT')
+            ->addJoinColumn('domain_id', 'id', onDelete: 'RESTRICT')
             ->cascadePersist()
             ->build();
 
     $builder->createManyToOne('authorApiKey', ApiKey::class)
-            ->addJoinColumn('author_api_key_id', 'id', true, false, 'SET NULL')
+            ->addJoinColumn('author_api_key_id', 'id', onDelete: 'SET NULL')
             ->build();
 
     $builder->addUniqueConstraint(['short_code', 'domain_id'], 'unique_short_code_plus_domain');

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.Visit.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.Visit.php
@@ -49,11 +49,11 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->build();
 
     $builder->createManyToOne('shortUrl', ShortUrl\Entity\ShortUrl::class)
-            ->addJoinColumn('short_url_id', 'id', true, false, 'CASCADE')
+            ->addJoinColumn('short_url_id', 'id', onDelete: 'CASCADE')
             ->build();
 
     $builder->createManyToOne('visitLocation', Visit\Entity\VisitLocation::class)
-            ->addJoinColumn('visit_location_id', 'id', true, false, 'Set NULL')
+            ->addJoinColumn('visit_location_id', 'id', onDelete: 'Set NULL')
             ->cascadePersist()
             ->build();
 

--- a/module/Core/migrations/Version20240224115725.php
+++ b/module/Core/migrations/Version20240224115725.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkMigrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240224115725 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf($schema->hasTable('short_url_redirect_rules'), 'New columns already exist');
+
+        $redirectRules = $this->createTableWithId($schema, 'short_url_redirect_rules');
+        $redirectRules->addColumn('priority', Types::INTEGER, ['unsigned' => true, 'default' => 1]);
+        // The length here is just so that Doctrine knows it should not use too small text types
+        $redirectRules->addColumn('long_url', Types::TEXT, ['length' => 2048]);
+
+        $redirectRules->addColumn('short_url_id', Types::BIGINT, [
+            'unsigned' => true,
+            'notnull' => true,
+        ]);
+        $redirectRules->addForeignKeyConstraint('short_urls', ['short_url_id'], ['id'], [
+            'onDelete' => 'CASCADE',
+            'onUpdate' => 'RESTRICT',
+        ]);
+
+        $redirectConditions = $this->createTableWithId($schema, 'redirect_conditions');
+        $redirectConditions->addColumn('name', Types::STRING, ['length' => 512]);
+        $redirectConditions->addUniqueIndex(['name'], 'UQ_name');
+
+        $redirectConditions->addColumn('type', Types::STRING, ['length' => 255]);
+        $redirectConditions->addColumn('match_key', Types::STRING, [
+            'length' => 512,
+            'notnull' => false,
+            'default' => null,
+        ]);
+        $redirectConditions->addColumn('match_value', Types::STRING, ['length' => 512]);
+
+        $joinTable = $schema->createTable('redirect_conditions_in_short_url_redirect_rules');
+
+        $joinTable->addColumn('redirect_condition_id', Types::BIGINT, [
+            'unsigned' => true,
+            'notnull' => true,
+        ]);
+        $joinTable->addForeignKeyConstraint('redirect_conditions', ['redirect_condition_id'], ['id'], [
+            'onDelete' => 'CASCADE',
+            'onUpdate' => 'RESTRICT',
+        ]);
+
+        $joinTable->addColumn('short_url_redirect_rule_id', Types::BIGINT, [
+            'unsigned' => true,
+            'notnull' => true,
+        ]);
+        $joinTable->addForeignKeyConstraint('short_url_redirect_rules', ['short_url_redirect_rule_id'], ['id'], [
+            'onDelete' => 'CASCADE',
+            'onUpdate' => 'RESTRICT',
+        ]);
+
+        $joinTable->setPrimaryKey(['redirect_condition_id', 'short_url_redirect_rule_id']);
+    }
+
+    private function createTableWithId(Schema $schema, string $tableName): Table
+    {
+        $table = $schema->createTable($tableName);
+        $table->addColumn('id', Types::BIGINT, [
+            'unsigned' => true,
+            'autoincrement' => true,
+            'notnull' => true,
+        ]);
+        $table->setPrimaryKey(['id']);
+
+        return $table;
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->skipIf(! $schema->hasTable('short_url_redirect_rules'), 'Columns do not exist');
+
+        $schema->dropTable('redirect_conditions_in_short_url_redirect_rules');
+        $schema->dropTable('short_url_redirect_rules');
+        $schema->dropTable('redirect_conditions');
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! ($this->connection->getDatabasePlatform() instanceof MySQLPlatform);
+    }
+}

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\RedirectRule\Entity;
+
+use Shlinkio\Shlink\Common\Entity\AbstractEntity;
+use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
+
+class RedirectCondition extends AbstractEntity
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly RedirectConditionType $type,
+        public readonly string $matchValue,
+        public readonly ?string $matchKey = null,
+    ) {
+    }
+}

--- a/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
+++ b/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\RedirectRule\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Shlinkio\Shlink\Common\Entity\AbstractEntity;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+class ShortUrlRedirectRule extends AbstractEntity
+{
+    /**
+     * @param Collection<RedirectCondition> $conditions
+     */
+    public function __construct(
+        private readonly ShortUrl $shortUrl, // No need to read this field. It's used by doctrine
+        public readonly int $priority,
+        public readonly string $longUrl,
+        public readonly Collection $conditions = new ArrayCollection(),
+    ) {
+    }
+}

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\RedirectRule\Model;
+
+enum RedirectConditionType: string
+{
+    case DEVICE = 'device';
+//    case LANGUAGE = 'language';
+//    case QUERY_PARAM = 'query';
+}


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/1914

This PR adds a database migration, new entities and the entities persistence config, to persist rule-based redirection data.

Entities have a temporary shape, and will be polished when the business logic and API are implemented.