### PR TITLE
Logic to resolve the long URL to redirect to for a short URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 ### Added
+* [#1902](https://github.com/shlinkio/shlink/issues/1902) Add dynamic redirects based on query parameters.
+
+  This is implemented on top of the new [rule-based redirects](https://github.com/shlinkio/shlink/discussions/1912).
+
 * [#1868](https://github.com/shlinkio/shlink/issues/1868) Add support for [docker compose secrets](https://docs.docker.com/compose/use-secrets/) to the docker image.
 * [#1979](https://github.com/shlinkio/shlink/issues/1979) Allow orphan visits lists to be filtered by type.
 

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "phpunit/phpunit": "^10.4",
         "roave/security-advisories": "dev-master",
         "shlinkio/php-coding-standard": "~2.3.0",
-        "shlinkio/shlink-test-utils": "^4.0",
+        "shlinkio/shlink-test-utils": "^4.1",
         "symfony/var-dumper": "^7.0",
         "veewee/composer-run-parallel": "^1.3"
     },

--- a/module/Core/config/dependencies.config.php
+++ b/module/Core/config/dependencies.config.php
@@ -32,6 +32,8 @@ return [
             Options\QrCodeOptions::class => [ValinorConfigFactory::class, 'config.qr_codes'],
             Options\RabbitMqOptions::class => [ValinorConfigFactory::class, 'config.rabbitmq'],
 
+            RedirectRule\ShortUrlRedirectionResolver::class => ConfigAbstractFactory::class,
+
             ShortUrl\UrlShortener::class => ConfigAbstractFactory::class,
             ShortUrl\ShortUrlService::class => ConfigAbstractFactory::class,
             ShortUrl\ShortUrlListService::class => ConfigAbstractFactory::class,
@@ -156,6 +158,7 @@ return [
         Util\RedirectResponseHelper::class => [Options\RedirectOptions::class],
 
         Config\NotFoundRedirectResolver::class => [Util\RedirectResponseHelper::class, 'Logger_Shlink'],
+        RedirectRule\ShortUrlRedirectionResolver::class => ['em'],
 
         Action\RedirectAction::class => [
             ShortUrl\ShortUrlResolver::class,
@@ -179,7 +182,10 @@ return [
         ],
         ShortUrl\Helper\ShortUrlStringifier::class => ['config.url_shortener.domain', 'config.router.base_path'],
         ShortUrl\Helper\ShortUrlTitleResolutionHelper::class => ['httpClient', Options\UrlShortenerOptions::class],
-        ShortUrl\Helper\ShortUrlRedirectionBuilder::class => [Options\TrackingOptions::class],
+        ShortUrl\Helper\ShortUrlRedirectionBuilder::class => [
+            Options\TrackingOptions::class,
+            RedirectRule\ShortUrlRedirectionResolver::class,
+        ],
         ShortUrl\Transformer\ShortUrlDataTransformer::class => [ShortUrl\Helper\ShortUrlStringifier::class],
         ShortUrl\Middleware\ExtraPathRedirectMiddleware::class => [
             ShortUrl\ShortUrlResolver::class,

--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -26,7 +26,9 @@ use function print_r;
 use function Shlinkio\Shlink\Common\buildDateRange;
 use function sprintf;
 use function str_repeat;
+use function str_replace;
 use function strtolower;
+use function trim;
 use function ucfirst;
 
 function generateRandomShortCode(int $length, ShortUrlMode $mode = ShortUrlMode::STRICT): string
@@ -72,6 +74,11 @@ function normalizeOptionalDate(string|DateTimeInterface|Chronos|null $date): ?Ch
 function normalizeDate(string|DateTimeInterface|Chronos $date): Chronos
 {
     return normalizeOptionalDate($date);
+}
+
+function normalizeLocale(string $locale): string
+{
+    return trim(strtolower(str_replace('_', '-', $locale)));
 }
 
 function getOptionalIntFromInputFilter(InputFilter $inputFilter, string $fieldName): ?int

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -16,8 +16,8 @@ class RedirectCondition extends AbstractEntity
     private function __construct(
         public readonly string $name,
         private readonly RedirectConditionType $type,
-        public readonly string $matchValue,
-        public readonly ?string $matchKey = null,
+        private readonly string $matchValue,
+        private readonly ?string $matchKey = null,
     ) {
     }
 

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -2,8 +2,13 @@
 
 namespace Shlinkio\Shlink\Core\RedirectRule\Entity;
 
+use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Common\Entity\AbstractEntity;
 use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
+
+use function explode;
+use function Shlinkio\Shlink\Core\ArrayUtils\some;
+use function Shlinkio\Shlink\Core\normalizeLocale;
 
 class RedirectCondition extends AbstractEntity
 {
@@ -13,5 +18,29 @@ class RedirectCondition extends AbstractEntity
         public readonly string $matchValue,
         public readonly ?string $matchKey = null,
     ) {
+    }
+
+    /**
+     * Tells if this condition matches provided request
+     */
+    public function matchesRequest(ServerRequestInterface $request): bool
+    {
+        if ($this->type === RedirectConditionType::QUERY_PARAM && $this->matchKey !== null) {
+            $query = $request->getQueryParams();
+            $queryValue = $query[$this->matchKey] ?? null;
+            return $queryValue === $this->matchValue;
+        }
+
+        if ($this->type === RedirectConditionType::LANGUAGE && $request->hasHeader('Accept-Language')) {
+            $acceptedLanguages = explode(',', $request->getHeaderLine('Accept-Language'));
+            $normalizedLanguage = normalizeLocale($this->matchValue);
+
+            return some(
+                $acceptedLanguages,
+                static fn (string $lang) => normalizeLocale($lang) === $normalizedLanguage,
+            );
+        }
+
+        return false;
     }
 }

--- a/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
+++ b/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
@@ -4,8 +4,11 @@ namespace Shlinkio\Shlink\Core\RedirectRule\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Common\Entity\AbstractEntity;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+use function Shlinkio\Shlink\Core\ArrayUtils\every;
 
 class ShortUrlRedirectRule extends AbstractEntity
 {
@@ -14,9 +17,20 @@ class ShortUrlRedirectRule extends AbstractEntity
      */
     public function __construct(
         private readonly ShortUrl $shortUrl, // No need to read this field. It's used by doctrine
-        public readonly int $priority,
+        private readonly int $priority,
         public readonly string $longUrl,
         public readonly Collection $conditions = new ArrayCollection(),
     ) {
+    }
+
+    /**
+     * Tells if this condition matches provided request
+     */
+    public function matchesRequest(ServerRequestInterface $request): bool
+    {
+        return every(
+            $this->conditions,
+            static fn (RedirectCondition $condition) => $condition->matchesRequest($request),
+        );
     }
 }

--- a/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
+++ b/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
@@ -28,7 +28,7 @@ class ShortUrlRedirectRule extends AbstractEntity
      */
     public function matchesRequest(ServerRequestInterface $request): bool
     {
-        return every(
+        return $this->conditions->count() > 0 && every(
             $this->conditions,
             static fn (RedirectCondition $condition) => $condition->matchesRequest($request),
         );

--- a/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
+++ b/module/Core/src/RedirectRule/Entity/ShortUrlRedirectRule.php
@@ -19,7 +19,7 @@ class ShortUrlRedirectRule extends AbstractEntity
         private readonly ShortUrl $shortUrl, // No need to read this field. It's used by doctrine
         private readonly int $priority,
         public readonly string $longUrl,
-        public readonly Collection $conditions = new ArrayCollection(),
+        private Collection $conditions = new ArrayCollection(),
     ) {
     }
 

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -4,7 +4,7 @@ namespace Shlinkio\Shlink\Core\RedirectRule\Model;
 
 enum RedirectConditionType: string
 {
-    case DEVICE = 'device';
-//    case LANGUAGE = 'language';
-//    case QUERY_PARAM = 'query';
+//    case DEVICE = 'device';
+    case LANGUAGE = 'language';
+    case QUERY_PARAM = 'query';
 }

--- a/module/Core/src/RedirectRule/ShortUrlRedirectionResolver.php
+++ b/module/Core/src/RedirectRule/ShortUrlRedirectionResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\RedirectRule;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Shlinkio\Shlink\Core\Model\DeviceType;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+readonly class ShortUrlRedirectionResolver implements ShortUrlRedirectionResolverInterface
+{
+    public function __construct(private EntityManagerInterface $em)
+    {
+    }
+
+    public function resolveLongUrl(ShortUrl $shortUrl, ServerRequestInterface $request): string
+    {
+        // TODO Resolve rules and check if any of them matches
+
+        $device = DeviceType::matchFromUserAgent($request->getHeaderLine('User-Agent'));
+        return $shortUrl->longUrlForDevice($device);
+    }
+}

--- a/module/Core/src/RedirectRule/ShortUrlRedirectionResolverInterface.php
+++ b/module/Core/src/RedirectRule/ShortUrlRedirectionResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\RedirectRule;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+interface ShortUrlRedirectionResolverInterface
+{
+    public function resolveLongUrl(ShortUrl $shortUrl, ServerRequestInterface $request): string;
+}

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace RedirectRule\Entity;
+
+use Laminas\Diactoros\ServerRequestFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
+
+class RedirectConditionTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['nop', '', false])] // param not present
+    #[TestWith(['foo', 'not-bar', false])] // param present with wrong value
+    #[TestWith(['foo', 'bar', true])] // param present with correct value
+    public function matchesQueryParams(string $param, string $value, bool $expectedResult): void
+    {
+        $request = ServerRequestFactory::fromGlobals()->withQueryParams(['foo' => 'bar']);
+        $result = RedirectCondition::forQueryParam($param, $value)->matchesRequest($request);
+
+        self::assertEquals($expectedResult, $result);
+    }
+
+    #[Test]
+    #[TestWith([null, '', false])] // no accept language
+    #[TestWith(['', '', false])] // empty accept language
+    #[TestWith(['*', '', false])] // wildcard accept language
+    #[TestWith(['en', 'en', true])] // single language match
+    #[TestWith(['es, en,fr', 'en', true])] // multiple languages match
+    #[TestWith(['es_ES', 'es-ES', true])] // single locale match
+    #[TestWith(['en-UK', 'en-uk', true])] // different casing match
+    public function matchesLanguage(?string $acceptLanguage, string $value, bool $expected): void
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        if ($acceptLanguage !== null) {
+            $request = $request->withHeader('Accept-Language', $acceptLanguage);
+        }
+
+        $result = RedirectCondition::forLanguage($value)->matchesRequest($request);
+
+        self::assertEquals($expected, $result);
+    }
+
+    #[Test, DataProvider('provideNames')]
+    public function generatesExpectedName(RedirectCondition $condition, string $expectedName): void
+    {
+        self::assertEquals($expectedName, $condition->name);
+    }
+
+    public static function provideNames(): iterable
+    {
+        yield [RedirectCondition::forLanguage('es-ES'), 'language-es-ES'];
+        yield [RedirectCondition::forLanguage('en_UK'), 'language-en_UK'];
+        yield [RedirectCondition::forQueryParam('foo', 'bar'), 'query-foo-bar'];
+        yield [RedirectCondition::forQueryParam('baz', 'foo'), 'query-baz-foo'];
+    }
+}

--- a/module/Core/test/RedirectRule/Entity/ShortUrlRedirectRuleTest.php
+++ b/module/Core/test/RedirectRule/Entity/ShortUrlRedirectRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace RedirectRule\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Laminas\Diactoros\ServerRequestFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\ShortUrlRedirectRule;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+class ShortUrlRedirectRuleTest extends TestCase
+{
+    #[Test, DataProvider('provideConditions')]
+    public function matchesRequestIfAllConditionsMatch(array $conditions, bool $expectedResult): void
+    {
+        $request = ServerRequestFactory::fromGlobals()
+            ->withHeader('Accept-Language', 'en-UK')
+            ->withQueryParams(['foo' => 'bar']);
+
+        $result = $this->createRule($conditions)->matchesRequest($request);
+
+        self::assertEquals($expectedResult, $result);
+    }
+
+    public static function provideConditions(): iterable
+    {
+        yield 'no conditions' => [[], false];
+        yield 'not all conditions match' => [
+            [RedirectCondition::forLanguage('en-UK'), RedirectCondition::forQueryParam('foo', 'foo')],
+            false,
+        ];
+        yield 'all conditions match' => [
+            [RedirectCondition::forLanguage('en-UK'), RedirectCondition::forQueryParam('foo', 'bar')],
+            true,
+        ];
+    }
+
+    /**
+     * @param RedirectCondition[] $conditions
+     */
+    private function createRule(array $conditions): ShortUrlRedirectRule
+    {
+        $shortUrl = ShortUrl::withLongUrl('https://s.test');
+        return new ShortUrlRedirectRule($shortUrl, 1, '', new ArrayCollection($conditions));
+    }
+}

--- a/module/Core/test/RedirectRule/ShortUrlRedirectionResolverTest.php
+++ b/module/Core/test/RedirectRule/ShortUrlRedirectionResolverTest.php
@@ -2,7 +2,9 @@
 
 namespace RedirectRule;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
 use Laminas\Diactoros\ServerRequestFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -10,6 +12,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Core\Model\DeviceType;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\ShortUrlRedirectRule;
 use Shlinkio\Shlink\Core\RedirectRule\ShortUrlRedirectionResolver;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlCreation;
@@ -30,8 +34,11 @@ class ShortUrlRedirectionResolverTest extends TestCase
     }
 
     #[Test, DataProvider('provideData')]
-    public function resolveLongUrlReturnsExpectedValue(ServerRequestInterface $request, string $expectedUrl): void
-    {
+    public function resolveLongUrlReturnsExpectedValue(
+        ServerRequestInterface $request,
+        ?RedirectCondition $condition,
+        string $expectedUrl,
+    ): void {
         $shortUrl = ShortUrl::create(ShortUrlCreation::fromRawData([
             'longUrl' => 'https://example.com/foo/bar',
             'deviceLongUrls' => [
@@ -39,6 +46,16 @@ class ShortUrlRedirectionResolverTest extends TestCase
                 DeviceType::IOS->value => 'https://example.com/ios',
             ],
         ]));
+
+        $repo = $this->createMock(EntityRepository::class);
+        $repo->expects($this->once())->method('findBy')->willReturn($condition !== null ? [
+            new ShortUrlRedirectRule($shortUrl, 1, 'https://example.com/from-rule', new ArrayCollection([
+                $condition,
+            ])),
+        ] : []);
+        $this->em->expects($this->once())->method('getRepository')->with(ShortUrlRedirectRule::class)->willReturn(
+            $repo,
+        );
 
         $result = $this->resolver->resolveLongUrl($shortUrl, $request);
 
@@ -52,9 +69,27 @@ class ShortUrlRedirectionResolverTest extends TestCase
             $userAgent,
         );
 
-        yield 'unknown user agent' => [$request('Unknown'), 'https://example.com/foo/bar'];
-        yield 'desktop user agent' => [$request(DESKTOP_USER_AGENT), 'https://example.com/foo/bar'];
-        yield 'android user agent' => [$request(ANDROID_USER_AGENT), 'https://example.com/android'];
-        yield 'ios user agent' => [$request(IOS_USER_AGENT), 'https://example.com/ios'];
+        yield 'unknown user agent' => [
+            $request('Unknown'), // This user agent won't match any device
+            RedirectCondition::forLanguage('es-ES'), // This condition won't match
+            'https://example.com/foo/bar',
+        ];
+        yield 'desktop user agent' => [$request(DESKTOP_USER_AGENT), null, 'https://example.com/foo/bar'];
+        yield 'android user agent' => [
+            $request(ANDROID_USER_AGENT),
+            RedirectCondition::forQueryParam('foo', 'bar'), // This condition won't match
+            'https://example.com/android',
+        ];
+        yield 'ios user agent' => [$request(IOS_USER_AGENT), null, 'https://example.com/ios'];
+        yield 'matching language' => [
+            $request()->withHeader('Accept-Language', 'es-ES'),
+            RedirectCondition::forLanguage('es-ES'),
+            'https://example.com/from-rule',
+        ];
+        yield 'matching query params' => [
+            $request()->withQueryParams(['foo' => 'bar']),
+            RedirectCondition::forQueryParam('foo', 'bar'),
+            'https://example.com/from-rule',
+        ];
     }
 }

--- a/module/Core/test/RedirectRule/ShortUrlRedirectionResolverTest.php
+++ b/module/Core/test/RedirectRule/ShortUrlRedirectionResolverTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace RedirectRule;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Laminas\Diactoros\ServerRequestFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Shlinkio\Shlink\Core\Model\DeviceType;
+use Shlinkio\Shlink\Core\RedirectRule\ShortUrlRedirectionResolver;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlCreation;
+
+use const ShlinkioTest\Shlink\ANDROID_USER_AGENT;
+use const ShlinkioTest\Shlink\DESKTOP_USER_AGENT;
+use const ShlinkioTest\Shlink\IOS_USER_AGENT;
+
+class ShortUrlRedirectionResolverTest extends TestCase
+{
+    private ShortUrlRedirectionResolver $resolver;
+    private EntityManagerInterface & MockObject $em;
+
+    protected function setUp(): void
+    {
+        $this->em = $this->createMock(EntityManagerInterface::class);
+        $this->resolver = new ShortUrlRedirectionResolver($this->em);
+    }
+
+    #[Test, DataProvider('provideData')]
+    public function resolveLongUrlReturnsExpectedValue(ServerRequestInterface $request, string $expectedUrl): void
+    {
+        $shortUrl = ShortUrl::create(ShortUrlCreation::fromRawData([
+            'longUrl' => 'https://example.com/foo/bar',
+            'deviceLongUrls' => [
+                DeviceType::ANDROID->value => 'https://example.com/android',
+                DeviceType::IOS->value => 'https://example.com/ios',
+            ],
+        ]));
+
+        $result = $this->resolver->resolveLongUrl($shortUrl, $request);
+
+        self::assertEquals($expectedUrl, $result);
+    }
+
+    public static function provideData(): iterable
+    {
+        $request = static fn (string $userAgent = '') => ServerRequestFactory::fromGlobals()->withHeader(
+            'User-Agent',
+            $userAgent,
+        );
+
+        yield 'unknown user agent' => [$request('Unknown'), 'https://example.com/foo/bar'];
+        yield 'desktop user agent' => [$request(DESKTOP_USER_AGENT), 'https://example.com/foo/bar'];
+        yield 'android user agent' => [$request(ANDROID_USER_AGENT), 'https://example.com/android'];
+        yield 'ios user agent' => [$request(IOS_USER_AGENT), 'https://example.com/ios'];
+    }
+}

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioApiTest\Shlink\Rest\Fixtures;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\ShortUrlRedirectRule;
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+
+class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentFixtureInterface
+{
+    public function getDependencies(): array
+    {
+        return [ShortUrlsFixture::class];
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        /** @var ShortUrl $defShortUrl */
+        $defShortUrl = $this->getReference('def456_short_url');
+
+        $englishCondition = RedirectCondition::forLanguage('en-UK');
+        $manager->persist($englishCondition);
+
+        $fooQueryCondition = RedirectCondition::forQueryParam('foo', 'bar');
+        $manager->persist($fooQueryCondition);
+
+        $helloQueryCondition = RedirectCondition::forQueryParam('hello', 'world');
+        $manager->persist($helloQueryCondition);
+
+        $englishAndFooQueryRule = new ShortUrlRedirectRule(
+            $defShortUrl,
+            1,
+            'https://example.com/english-and-foo-query',
+            new ArrayCollection([$englishCondition, $fooQueryCondition]),
+        );
+        $manager->persist($englishAndFooQueryRule);
+
+        $multipleQueryParamsRule = new ShortUrlRedirectRule(
+            $defShortUrl,
+            2,
+            'https://example.com/multiple-query-params',
+            new ArrayCollection([$helloQueryCondition, $fooQueryCondition]),
+        );
+        $manager->persist($multipleQueryParamsRule);
+
+        $onlyEnglishRule = new ShortUrlRedirectRule(
+            $defShortUrl,
+            3,
+            'https://example.com/only-english',
+            new ArrayCollection([$englishCondition]),
+        );
+        $manager->persist($onlyEnglishRule);
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/1914

Closes https://github.com/shlinkio/shlink/issues/1902

Implement logic to dynamically redirect to different long URLs based on dynamic rules.

Also, implement logic specific to redirect dynamically based on query params, and partially for redirects based on accept language.

Todo:

- [x] Finish unit tests
- [x] Add E2E tests