### PR TITLE
Feature/language redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
   This is implemented on top of the new [rule-based redirects](https://github.com/shlinkio/shlink/discussions/1912).
 
+* [#1915](https://github.com/shlinkio/shlink/issues/1915) Add dynamic redirects based on accept language.
+
+  This is implemented on top of the new [rule-based redirects](https://github.com/shlinkio/shlink/discussions/1912).
+
 * [#1868](https://github.com/shlinkio/shlink/issues/1868) Add support for [docker compose secrets](https://docs.docker.com/compose/use-secrets/) to the docker image.
 * [#1979](https://github.com/shlinkio/shlink/issues/1979) Allow orphan visits lists to be filtered by type.
 

--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -16,10 +16,13 @@ use PUGX\Shortid\Factory as ShortIdFactory;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlMode;
 
+use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_pad;
 use function array_reduce;
 use function date_default_timezone_get;
+use function explode;
 use function implode;
 use function is_array;
 use function print_r;
@@ -79,6 +82,33 @@ function normalizeDate(string|DateTimeInterface|Chronos $date): Chronos
 function normalizeLocale(string $locale): string
 {
     return trim(strtolower(str_replace('_', '-', $locale)));
+}
+
+/**
+ * @param non-empty-string $acceptLanguage
+ * @return string[];
+ */
+function acceptLanguageToLocales(string $acceptLanguage): array
+{
+    $acceptLanguagesList = array_map(function (string $lang): string {
+        [$lang] = explode(';', $lang); // Discard everything after the semicolon (en-US;q=0.7)
+        return normalizeLocale($lang);
+    }, explode(',', $acceptLanguage));
+    return array_filter($acceptLanguagesList, static fn (string $lang) => $lang !== '*');
+}
+
+/**
+ * Splits a locale into its corresponding language and country codes.
+ * The country code will be null if not present
+ *   'es-AR' -> ['es', 'AR']
+ *   'fr-FR' -> ['fr', 'FR']
+ *   'en' -> ['en', null]
+ *
+ * @return array{string, string|null}
+ */
+function splitLocale(string $locale): array
+{
+    return array_pad(explode('-', $locale), 2, null);
 }
 
 function getOptionalIntFromInputFilter(InputFilter $inputFilter, string $fieldName): ?int

--- a/module/Core/test-api/Action/RedirectTest.php
+++ b/module/Core/test-api/Action/RedirectTest.php
@@ -50,9 +50,7 @@ class RedirectTest extends ApiTestCase
         ];
         yield 'rule: english and foo' => [
             [
-                RequestOptions::HEADERS => [
-                    'Accept-Language' => 'en-UK',
-                ],
+                RequestOptions::HEADERS => ['Accept-Language' => 'en-UK'],
                 RequestOptions::QUERY => ['foo' => 'bar'],
             ],
             'https://example.com/english-and-foo-query?foo=bar',
@@ -63,9 +61,21 @@ class RedirectTest extends ApiTestCase
             ],
             'https://example.com/multiple-query-params?foo=bar&hello=world',
         ];
-        yield 'rule: english' => [
+        yield 'rule: british english' => [
             [
                 RequestOptions::HEADERS => ['Accept-Language' => 'en-UK'],
+            ],
+            'https://example.com/only-english',
+        ];
+        yield 'rule: english' => [
+            [
+                RequestOptions::HEADERS => ['Accept-Language' => 'en'],
+            ],
+            'https://example.com/only-english',
+        ];
+        yield 'rule: complex matching accept language' => [
+            [
+                RequestOptions::HEADERS => ['Accept-Language' => 'fr-FR, es;q=08, en;q=0.5, *;q=0.2'],
             ],
             'https://example.com/only-english',
         ];

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -29,8 +29,12 @@ class RedirectConditionTest extends TestCase
     #[TestWith(['*', '', false])] // wildcard accept language
     #[TestWith(['en', 'en', true])] // single language match
     #[TestWith(['es, en,fr', 'en', true])] // multiple languages match
+    #[TestWith(['es, en-US,fr', 'EN', true])] // multiple locales match
     #[TestWith(['es_ES', 'es-ES', true])] // single locale match
     #[TestWith(['en-UK', 'en-uk', true])] // different casing match
+    #[TestWith(['en-UK', 'en', true])] // only lang
+    #[TestWith(['es-AR', 'en', false])] // different only lang
+    #[TestWith(['fr', 'fr-FR', false])] // less restrictive matching locale
     public function matchesLanguage(?string $acceptLanguage, string $value, bool $expected): void
     {
         $request = ServerRequestFactory::fromGlobals();

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -24,7 +24,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
         /** @var ShortUrl $defShortUrl */
         $defShortUrl = $this->getReference('def456_short_url');
 
-        $englishCondition = RedirectCondition::forLanguage('en-UK');
+        $englishCondition = RedirectCondition::forLanguage('en');
         $manager->persist($englishCondition);
 
         $fooQueryCondition = RedirectCondition::forQueryParam('foo', 'bar');


### PR DESCRIPTION
Closes #1915 

This PR adds logic to match language-based redirect conditions from standard `Accept-Language` headers, as described [in MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language).

Matching is done from more strict to less strict, which means, if the match value is just the language code (`en`, `fr`, `it`, etc), any locale for that language will return a positive match (`en-US`, `en-UK`, `en-AU`, etc).

If the `Accept-Language` header contains multiple languages, the rule above will be applied against all of them, and return a positive match as soon as one of them matches.

If the `Accept-Language` header has value `*`, it will be considered a negative match, as this would always match otherwise.