### PR TITLE
Remove name and uniqueness in redirect condition table

### DIFF
--- a/docs/swagger/paths/v3_short-urls_{shortCode}_redirect-rules.json
+++ b/docs/swagger/paths/v3_short-urls_{shortCode}_redirect-rules.json
@@ -50,13 +50,11 @@
                   "priority": 1,
                   "conditions": [
                     {
-                      "name": "device-android",
                       "type": "device",
                       "matchValue": "android",
                       "matchKey": null
                     },
                     {
-                      "name": "language-en-US",
                       "type": "language",
                       "matchValue": "en-US",
                       "matchKey": null
@@ -68,7 +66,6 @@
                   "priority": 2,
                   "conditions": [
                     {
-                      "name": "language-fr",
                       "type": "language",
                       "matchValue": "fr",
                       "matchKey": null
@@ -80,13 +77,11 @@
                   "priority": 3,
                   "conditions": [
                     {
-                      "name": "query-foo-bar",
                       "type": "query",
                       "matchKey": "foo",
                       "matchValue": "bar"
                     },
                     {
-                      "name": "query-hello-world",
                       "type": "query",
                       "matchKey": "hello",
                       "matchValue": "world"

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
@@ -22,13 +22,6 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->option('unsigned', true)
             ->build();
 
-    fieldWithUtf8Charset($builder->createField('name', Types::STRING), $emConfig)
-        ->columnName('name')
-        ->length(512)
-        ->build();
-
-    $builder->addUniqueConstraint(['name'], 'UQ_name');
-
     (new FieldBuilder($builder, [
         'fieldName' => 'type',
         'type' => Types::STRING,

--- a/module/Core/migrations/Version20240224115725.php
+++ b/module/Core/migrations/Version20240224115725.php
@@ -34,8 +34,6 @@ final class Version20240224115725 extends AbstractMigration
         ]);
 
         $redirectConditions = $this->createTableWithId($schema, 'redirect_conditions');
-        $redirectConditions->addColumn('name', Types::STRING, ['length' => 512]);
-        $redirectConditions->addUniqueIndex(['name'], 'UQ_name');
 
         $redirectConditions->addColumn('type', Types::STRING, ['length' => 255]);
         $redirectConditions->addColumn('match_key', Types::STRING, [

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -12,14 +12,12 @@ use function Shlinkio\Shlink\Core\acceptLanguageToLocales;
 use function Shlinkio\Shlink\Core\ArrayUtils\some;
 use function Shlinkio\Shlink\Core\normalizeLocale;
 use function Shlinkio\Shlink\Core\splitLocale;
-use function sprintf;
 use function strtolower;
 use function trim;
 
 class RedirectCondition extends AbstractEntity implements JsonSerializable
 {
     private function __construct(
-        public readonly string $name,
         private readonly RedirectConditionType $type,
         private readonly string $matchValue,
         private readonly ?string $matchKey = null,
@@ -28,26 +26,17 @@ class RedirectCondition extends AbstractEntity implements JsonSerializable
 
     public static function forQueryParam(string $param, string $value): self
     {
-        $type = RedirectConditionType::QUERY_PARAM;
-        $name = sprintf('%s-%s-%s', $type->value, $param, $value);
-
-        return new self($name, $type, $value, $param);
+        return new self(RedirectConditionType::QUERY_PARAM, $value, $param);
     }
 
     public static function forLanguage(string $language): self
     {
-        $type = RedirectConditionType::LANGUAGE;
-        $name = sprintf('%s-%s', $type->value, $language);
-
-        return new self($name, $type, $language);
+        return new self(RedirectConditionType::LANGUAGE, $language);
     }
 
     public static function forDevice(DeviceType $device): self
     {
-        $type = RedirectConditionType::DEVICE;
-        $name = sprintf('%s-%s', $type->value, $device->value);
-
-        return new self($name, $type, $device->value);
+        return new self(RedirectConditionType::DEVICE, $device->value);
     }
 
     /**
@@ -103,7 +92,6 @@ class RedirectCondition extends AbstractEntity implements JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'name' => $this->name,
             'type' => $this->type->value,
             'matchKey' => $this->matchKey,
             'matchValue' => $this->matchValue,

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -3,7 +3,6 @@
 namespace ShlinkioTest\Shlink\Core\RedirectRule\Entity;
 
 use Laminas\Diactoros\ServerRequestFactory;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -70,22 +69,5 @@ class RedirectConditionTest extends TestCase
         $result = RedirectCondition::forDevice($value)->matchesRequest($request);
 
         self::assertEquals($expected, $result);
-    }
-
-    #[Test, DataProvider('provideNames')]
-    public function generatesExpectedName(RedirectCondition $condition, string $expectedName): void
-    {
-        self::assertEquals($expectedName, $condition->name);
-    }
-
-    public static function provideNames(): iterable
-    {
-        yield [RedirectCondition::forLanguage('es-ES'), 'language-es-ES'];
-        yield [RedirectCondition::forLanguage('en_UK'), 'language-en_UK'];
-        yield [RedirectCondition::forQueryParam('foo', 'bar'), 'query-foo-bar'];
-        yield [RedirectCondition::forQueryParam('baz', 'foo'), 'query-baz-foo'];
-        yield [RedirectCondition::forDevice(DeviceType::ANDROID), 'device-android'];
-        yield [RedirectCondition::forDevice(DeviceType::IOS), 'device-ios'];
-        yield [RedirectCondition::forDevice(DeviceType::DESKTOP), 'device-desktop'];
     }
 }

--- a/module/Rest/test-api/Action/ListRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/ListRedirectRulesTest.php
@@ -13,13 +13,11 @@ use function sprintf;
 class ListRedirectRulesTest extends ApiTestCase
 {
     private const LANGUAGE_EN_CONDITION = [
-        'name' => 'language-en',
         'type' => 'language',
         'matchKey' => null,
         'matchValue' => 'en',
     ];
     private const QUERY_FOO_BAR_CONDITION = [
-        'name' => 'query-foo-bar',
         'type' => 'query',
         'matchKey' => 'foo',
         'matchValue' => 'bar',
@@ -54,13 +52,12 @@ class ListRedirectRulesTest extends ApiTestCase
             'longUrl' => 'https://example.com/multiple-query-params',
             'priority' => 2,
             'conditions' => [
-                self::QUERY_FOO_BAR_CONDITION,
                 [
-                    'name' => 'query-hello-world',
                     'type' => 'query',
                     'matchKey' => 'hello',
                     'matchValue' => 'world',
                 ],
+                self::QUERY_FOO_BAR_CONDITION,
             ],
         ],
         [
@@ -73,7 +70,6 @@ class ListRedirectRulesTest extends ApiTestCase
             'priority' => 4,
             'conditions' => [
                 [
-                    'name' => 'device-android',
                     'type' => 'device',
                     'matchKey' => null,
                     'matchValue' => 'android',
@@ -85,7 +81,6 @@ class ListRedirectRulesTest extends ApiTestCase
             'priority' => 5,
             'conditions' => [
                 [
-                    'name' => 'device-ios',
                     'type' => 'device',
                     'matchKey' => null,
                     'matchValue' => 'ios',

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -25,27 +25,14 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
         /** @var ShortUrl $defShortUrl */
         $defShortUrl = $this->getReference('def456_short_url');
 
-        $englishCondition = RedirectCondition::forLanguage('en');
-        $manager->persist($englishCondition);
-
-        $fooQueryCondition = RedirectCondition::forQueryParam('foo', 'bar');
-        $manager->persist($fooQueryCondition);
-
-        $helloQueryCondition = RedirectCondition::forQueryParam('hello', 'world');
-        $manager->persist($helloQueryCondition);
-
-        $androidCondition = RedirectCondition::forDevice(DeviceType::ANDROID);
-        $manager->persist($androidCondition);
-
-        $iosCondition = RedirectCondition::forDevice(DeviceType::IOS);
-        $manager->persist($iosCondition);
-
         // Create rules disordered to make sure the order by priority works
         $multipleQueryParamsRule = new ShortUrlRedirectRule(
             shortUrl: $defShortUrl,
             priority: 2,
             longUrl: 'https://example.com/multiple-query-params',
-            conditions: new ArrayCollection([$helloQueryCondition, $fooQueryCondition]),
+            conditions: new ArrayCollection(
+                [RedirectCondition::forQueryParam('hello', 'world'), RedirectCondition::forQueryParam('foo', 'bar')],
+            ),
         );
         $manager->persist($multipleQueryParamsRule);
 
@@ -53,7 +40,9 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
             shortUrl: $defShortUrl,
             priority: 1,
             longUrl: 'https://example.com/english-and-foo-query',
-            conditions: new ArrayCollection([$englishCondition, $fooQueryCondition]),
+            conditions: new ArrayCollection(
+                [RedirectCondition::forLanguage('en'), RedirectCondition::forQueryParam('foo', 'bar')],
+            ),
         );
         $manager->persist($englishAndFooQueryRule);
 
@@ -61,7 +50,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
             shortUrl: $defShortUrl,
             priority: 4,
             longUrl: 'https://blog.alejandrocelaya.com/android',
-            conditions: new ArrayCollection([$androidCondition]),
+            conditions: new ArrayCollection([RedirectCondition::forDevice(DeviceType::ANDROID)]),
         );
         $manager->persist($androidRule);
 
@@ -69,7 +58,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
             shortUrl: $defShortUrl,
             priority: 3,
             longUrl: 'https://example.com/only-english',
-            conditions: new ArrayCollection([$englishCondition]),
+            conditions: new ArrayCollection([RedirectCondition::forLanguage('en')]),
         );
         $manager->persist($onlyEnglishRule);
 
@@ -77,7 +66,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
             shortUrl: $defShortUrl,
             priority: 5,
             longUrl: 'https://blog.alejandrocelaya.com/ios',
-            conditions: new ArrayCollection([$iosCondition]),
+            conditions: new ArrayCollection([RedirectCondition::forDevice(DeviceType::IOS)]),
         );
         $manager->persist($iosRule);
 


### PR DESCRIPTION
Part of #1914 

During the implementation of the API to handle redirect rules and conditions, it was made obvious that a normalized version of rules<->relation_table<->conditions would not be as easy to handle, so I thought it would make more sense to switch from a many-to-many relationship to a one-to-many.

However, we want rules to know about conditions, but not the other way around, and Doctrine does not handle inversed unidirectional one-to-many relationships so well.

Because of that, this keeps the many-to-many relationship, but refactoring it so that conditions are not unique nor shared between rules anymore. Instead, every rule will have its conditions, that will be removed when orphaned.

That requires removing the `name` filed from conditions, which acted as a unique key, and making conditions to cascade persist, as they will always be created together with "their" rule.