### PR TITLE
Define different swagger models for get and set redirect rules

### DIFF
--- a/docs/swagger/definitions/SetShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/SetShortUrlRedirectRule.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "required": ["longUrl", "conditions"],
+  "properties": {
+    "longUrl": {
+      "description": "Long URL to redirect to when this condition matches",
+      "type": "string"
+    },
+    "conditions": {
+      "description": "List of conditions that need to match in order to consider this rule matches",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["type", "matchKey", "matchValue"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["device", "language", "query"],
+            "description": "The type of the condition, which will condition the logic used to match it"
+          },
+          "matchKey":  {
+            "type": ["string", "null"]
+          },
+          "matchValue":  {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/swagger/definitions/ShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/ShortUrlRedirectRule.json
@@ -1,35 +1,13 @@
 {
   "type": "object",
-  "required": ["priority", "longUrl", "conditions"],
+  "required": ["priority"],
   "properties": {
-    "longUrl": {
-      "description": "Long URL to redirect to when this condition matches",
-      "type": "string"
-    },
     "priority": {
       "description": "Order in which attempting to match the rule. Lower goes first",
       "type": "number"
-    },
-    "conditions": {
-      "description": "List of conditions that need to match in order to consider this rule matches",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["type", "matchKey", "matchValue"],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["device", "language", "query"],
-            "description": "The type of the condition, which will condition the logic used to match it"
-          },
-          "matchKey":  {
-            "type": ["string", "null"]
-          },
-          "matchValue":  {
-            "type": "string"
-          }
-        }
-      }
     }
-  }
+  },
+  "allOf": [{
+    "$ref": "./SetShortUrlRedirectRule.json"
+  }]
 }

--- a/docs/swagger/paths/v3_short-urls_{shortCode}_redirect-rules.json
+++ b/docs/swagger/paths/v3_short-urls_{shortCode}_redirect-rules.json
@@ -145,7 +145,7 @@
       "Redirect rules"
     ],
     "summary": "Set short URL redirect rules",
-    "description": "Overwrites redirect rules for a short URL with the ones provided here.",
+    "description": "Sets redirect rules for a short URL, with priorities matching the order in which they are provided.",
     "parameters": [
       {
         "$ref": "../parameters/version.json"
@@ -173,10 +173,54 @@
               "redirectRules": {
                 "type": "array",
                 "items": {
-                  "$ref": "../definitions/ShortUrlRedirectRule.json"
+                  "$ref": "../definitions/SetShortUrlRedirectRule.json"
                 }
               }
             }
+          },
+          "example": {
+            "redirectRules": [
+              {
+                "longUrl": "https://example.com/android-en-us",
+                "conditions": [
+                  {
+                    "type": "device",
+                    "matchValue": "android",
+                    "matchKey": null
+                  },
+                  {
+                    "type": "language",
+                    "matchValue": "en-US",
+                    "matchKey": null
+                  }
+                ]
+              },
+              {
+                "longUrl": "https://example.com/fr",
+                "conditions": [
+                  {
+                    "type": "language",
+                    "matchValue": "fr",
+                    "matchKey": null
+                  }
+                ]
+              },
+              {
+                "longUrl": "https://example.com/query-foo-bar-hello-world",
+                "conditions": [
+                  {
+                    "type": "query",
+                    "matchKey": "foo",
+                    "matchValue": "bar"
+                  },
+                  {
+                    "type": "query",
+                    "matchKey": "hello",
+                    "matchValue": "world"
+                  }
+                ]
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
Part of #1914 

Document differences between API models to set redirect rules (which do not have a `priority` property) and the responses.