### PR TITLE
Ensure language redirect conditions do not match for too low quality accepted languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 ### Added
-* [#2041](https://github.com/shlinkio/shlink/issues/2041) Document `color` and `bgColor` params for the QR code route in the OAS docs.
+* *Nothing*
 
 ### Changed
 * *Nothing*
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#2041](https://github.com/shlinkio/shlink/issues/2041) Document missing `color` and `bgColor` params for the QR code route in the OAS docs.
+* [#2043](https://github.com/shlinkio/shlink/issues/2043) Fix language redirect conditions matching too low quality accepted languages.
 
 
 ## [4.0.0] - 2024-03-03

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -77,7 +77,7 @@ class RedirectCondition extends AbstractEntity implements JsonSerializable
             return false;
         }
 
-        $acceptedLanguages = acceptLanguageToLocales($acceptLanguage);
+        $acceptedLanguages = acceptLanguageToLocales($acceptLanguage, minQuality: 0.9);
         [$matchLanguage, $matchCountryCode] = splitLocale(normalizeLocale($this->matchValue));
 
         return some(

--- a/module/Core/test-api/Action/RedirectTest.php
+++ b/module/Core/test-api/Action/RedirectTest.php
@@ -75,9 +75,15 @@ class RedirectTest extends ApiTestCase
         ];
         yield 'rule: complex matching accept language' => [
             [
-                RequestOptions::HEADERS => ['Accept-Language' => 'fr-FR, es;q=08, en;q=0.5, *;q=0.2'],
+                RequestOptions::HEADERS => ['Accept-Language' => 'fr-FR, es;q=0.9, en;q=0.9, *;q=0.2'],
             ],
             'https://example.com/only-english',
+        ];
+        yield 'rule: too low quality accept language' => [
+            [
+                RequestOptions::HEADERS => ['Accept-Language' => 'fr-FR, es;q=0.8, en;q=0.5, *;q=0.2'],
+            ],
+            'https://blog.alejandrocelaya.com/2017/12/09/acmailer-7-0-the-most-important-release-in-a-long-time/',
         ];
     }
 }

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -35,6 +35,8 @@ class RedirectConditionTest extends TestCase
     #[TestWith(['es, en,fr', 'en', true])] // multiple languages match
     #[TestWith(['es, en-US,fr', 'EN', true])] // multiple locales match
     #[TestWith(['es_ES', 'es-ES', true])] // single locale match
+    #[TestWith(['en-US,es-ES;q=0.6', 'es-ES', false])] // too low quality
+    #[TestWith(['en-US,es-ES;q=0.9', 'es-ES', true])] // quality high enough
     #[TestWith(['en-UK', 'en-uk', true])] // different casing match
     #[TestWith(['en-UK', 'en', true])] // only lang
     #[TestWith(['es-AR', 'en', false])] // different only lang


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink/issues/2043

In the initial implementation for language redirect conditions, I decided to let it match for any language present in the `Accept-Language` header, with the only exception of `*`.

Unfortunately, due to how browsers decide which languages to send in the `Accept-Language` header, this resulted in unexpected matching rules when multiple rules are configured for different languages.

For example, if you configure a rule for English and then a rule for Spanish, with an accept language like `es-ES,es;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6` the English condition would positively match if it has more priority than the Spanish one, when intuition says that this header should match the Spanish condition.

This PR changes the logic when matching languages, so that a minimum 0.9 quality is required for languages in the `Accept-Language` header.

In the example above, that would mean that only `es-ES` and `es` would end up being evaluated, and the rest would be ignored.

As a side effect, that would mean that someone with the header `fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7,ja;q=0.6` would not match the English rule anymore, while it would with previous approach. However, the expected behavior would probably be that no rule matches, and instead redirection falls back to the default long URL, so this is probably correct.