### PR TITLE
Fix infinite GeoLite2 downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.0.2] - 2024-03-09
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2021](https://github.com/shlinkio/shlink/issues/2021) Fix infinite GeoLite2 downloads.
+
+
 ## [4.0.1] - 2024-03-08
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "shlinkio/shlink-event-dispatcher": "^4.0",
         "shlinkio/shlink-importer": "^5.3",
         "shlinkio/shlink-installer": "^9.0",
-        "shlinkio/shlink-ip-geolocation": "^3.5",
+        "shlinkio/shlink-ip-geolocation": "^4.0",
         "shlinkio/shlink-json": "^1.1",
         "spiral/roadrunner": "^2023.3",
         "spiral/roadrunner-cli": "^2.6",

--- a/module/CLI/config/dependencies.config.php
+++ b/module/CLI/config/dependencies.config.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\CLI;
 
-use GeoIp2\Database\Reader;
 use Laminas\ServiceManager\AbstractFactory\ConfigAbstractFactory;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Shlinkio\Shlink\Common\Doctrine\NoDbNameConnectionFactory;
@@ -18,6 +17,7 @@ use Shlinkio\Shlink\Core\Tag\TagService;
 use Shlinkio\Shlink\Core\Visit;
 use Shlinkio\Shlink\Installer\Factory\ProcessHelperFactory;
 use Shlinkio\Shlink\IpGeolocation\GeoLite2\DbUpdater;
+use Shlinkio\Shlink\IpGeolocation\GeoLite2\GeoLite2ReaderFactory;
 use Shlinkio\Shlink\Rest\Service\ApiKeyService;
 use Symfony\Component\Console as SymfonyCli;
 use Symfony\Component\Lock\LockFactory;
@@ -76,7 +76,7 @@ return [
     ConfigAbstractFactory::class => [
         GeoLite\GeolocationDbUpdater::class => [
             DbUpdater::class,
-            Reader::class,
+            GeoLite2ReaderFactory::class,
             LOCAL_LOCK_FACTORY,
             TrackingOptions::class,
         ],

--- a/module/CLI/test/GeoLite/GeolocationDbUpdaterTest.php
+++ b/module/CLI/test/GeoLite/GeolocationDbUpdaterTest.php
@@ -187,7 +187,7 @@ class GeolocationDbUpdaterTest extends TestCase
 
         return new GeolocationDbUpdater(
             $this->dbUpdater,
-            $this->geoLiteDbReader,
+            fn () => $this->geoLiteDbReader,
             $locker,
             $options ?? new TrackingOptions(),
         );


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink/issues/2021

This PR uses the new `GeoLite2ReaderFactory` introduced in https://github.com/shlinkio/shlink-ip-geolocation/pull/60, in order to fix an infinite GeoLite2 download loop caused by old metadata being cached in memory by a stateful object registered as a singleton service.

The `GeoLite2ReaderFactory` creates new instances of that object every time, solving that problem.