### PR TITLE
Feature/string db credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2058](https://github.com/shlinkio/shlink/issues/2058) Fix DB credentials provided as env vars being casted to `int` if they include only numbers.
+
+
 ## [4.0.2] - 2024-03-09
 ### Added
 * *Nothing*

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -16,6 +16,10 @@ return (static function (): array {
         'mssql' => 'pdo_sqlsrv',
         default => 'pdo_mysql',
     };
+    $readCredentialAsString = static function (EnvVars $envVar): string|null {
+        $value = $envVar->loadFromEnv();
+        return $value === null ? null : (string) $value;
+    };
     $resolveDefaultPort = static fn () => match ($driver) {
         'postgres' => '5432',
         'mssql' => '1433',
@@ -28,6 +32,7 @@ return (static function (): array {
         'postgres' => 'utf8',
         default => null,
     };
+
     $resolveConnection = static fn () => match ($driver) {
         null, 'sqlite' => [
             'driver' => 'pdo_sqlite',
@@ -36,8 +41,8 @@ return (static function (): array {
         default => [
             'driver' => $resolveDriver(),
             'dbname' => EnvVars::DB_NAME->loadFromEnv('shlink'),
-            'user' => EnvVars::DB_USER->loadFromEnv(),
-            'password' => EnvVars::DB_PASSWORD->loadFromEnv(),
+            'user' => $readCredentialAsString(EnvVars::DB_USER),
+            'password' => $readCredentialAsString(EnvVars::DB_PASSWORD),
             'host' => EnvVars::DB_HOST->loadFromEnv(EnvVars::DB_UNIX_SOCKET->loadFromEnv()),
             'port' => EnvVars::DB_PORT->loadFromEnv($resolveDefaultPort()),
             'unix_socket' => $isMysqlCompatible ? EnvVars::DB_UNIX_SOCKET->loadFromEnv() : null,


### PR DESCRIPTION
Closes #2058 

Make sure database user and password are casted to string when read as env vars.

This is a workaround for a problem caused by how env vars are read and type-casted in Shlink. Right now, they are converted to a specific type based in their value, while they should probably be type-casted based on the context they are going to be used on.

However, this requires more changes and considerations, and it could end up introducing other problems.

This just fixes the specific problems reported in #2058, and delays any further changes.