### PR TITLE
Fix error when redirecting to a non-http URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [4.0.3] - 2024-03-15
 ### Added
 * *Nothing*
 
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Fixed
 * [#2058](https://github.com/shlinkio/shlink/issues/2058) Fix DB credentials provided as env vars being casted to `int` if they include only numbers.
+* [#2060](https://github.com/shlinkio/shlink/issues/2060) Fix error when trying to redirect to a non-http long URL.
 
 
 ## [4.0.2] - 2024-03-09

--- a/module/Core/src/ShortUrl/Middleware/ExtraPathRedirectMiddleware.php
+++ b/module/Core/src/ShortUrl/Middleware/ExtraPathRedirectMiddleware.php
@@ -87,7 +87,7 @@ class ExtraPathRedirectMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @return array{0: string, 1: string|null}
+     * @return array{string, string|null}
      */
     private function resolvePotentialShortCodeAndExtraPath(UriInterface $uri, int $shortCodeSegments): array
     {

--- a/module/Rest/test-api/Action/ListRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/ListRedirectRulesTest.php
@@ -66,7 +66,7 @@ class ListRedirectRulesTest extends ApiTestCase
             'conditions' => [self::LANGUAGE_EN_CONDITION],
         ],
         [
-            'longUrl' => 'https://blog.alejandrocelaya.com/android',
+            'longUrl' => 'android://foo/bar',
             'priority' => 4,
             'conditions' => [
                 [
@@ -77,7 +77,7 @@ class ListRedirectRulesTest extends ApiTestCase
             ],
         ],
         [
-            'longUrl' => 'https://blog.alejandrocelaya.com/ios',
+            'longUrl' => 'fb://profile/33138223345',
             'priority' => 5,
             'conditions' => [
                 [

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -49,7 +49,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
         $androidRule = new ShortUrlRedirectRule(
             shortUrl: $defShortUrl,
             priority: 4,
-            longUrl: 'https://blog.alejandrocelaya.com/android',
+            longUrl: 'android://foo/bar',
             conditions: new ArrayCollection([RedirectCondition::forDevice(DeviceType::ANDROID)]),
         );
         $manager->persist($androidRule);
@@ -65,7 +65,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
         $iosRule = new ShortUrlRedirectRule(
             shortUrl: $defShortUrl,
             priority: 5,
-            longUrl: 'https://blog.alejandrocelaya.com/ios',
+            longUrl: 'fb://profile/33138223345',
             conditions: new ArrayCollection([RedirectCondition::forDevice(DeviceType::IOS)]),
         );
         $manager->persist($iosRule);


### PR DESCRIPTION
Closes #2060 

Fix an error when trying to redirect to a non-http URL (like the ones used for deeplinks, for example).

This PR also adds a bunch of tests covering that, as this was a regression introduced in https://github.com/shlinkio/shlink/pull/1991/files#diff-abf169189b40a92b43093bda1780b27f63581b5fc9c4644fca78c5913773acd8