### PR TITLE
Move logic to serialize ShortUrls to entity itself

### DIFF
--- a/module/Core/src/ShortUrl/DeleteShortUrlService.php
+++ b/module/Core/src/ShortUrl/DeleteShortUrlService.php
@@ -43,10 +43,8 @@ class DeleteShortUrlService implements DeleteShortUrlServiceInterface
 
     private function isThresholdReached(ShortUrl $shortUrl): bool
     {
-        if (! $this->deleteShortUrlsOptions->checkVisitsThreshold) {
-            return false;
-        }
-
-        return $shortUrl->getVisitsCount() >= $this->deleteShortUrlsOptions->visitsThreshold;
+        return $this->deleteShortUrlsOptions->checkVisitsThreshold && $shortUrl->reachedVisits(
+            $this->deleteShortUrlsOptions->visitsThreshold,
+        );
     }
 }

--- a/module/Core/src/ShortUrl/Transformer/ShortUrlDataTransformer.php
+++ b/module/Core/src/ShortUrl/Transformer/ShortUrlDataTransformer.php
@@ -7,14 +7,10 @@ namespace Shlinkio\Shlink\Core\ShortUrl\Transformer;
 use Shlinkio\Shlink\Common\Rest\DataTransformerInterface;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifierInterface;
-use Shlinkio\Shlink\Core\Tag\Entity\Tag;
-use Shlinkio\Shlink\Core\Visit\Model\VisitsSummary;
 
-use function array_map;
-
-class ShortUrlDataTransformer implements DataTransformerInterface
+readonly class ShortUrlDataTransformer implements DataTransformerInterface
 {
-    public function __construct(private readonly ShortUrlStringifierInterface $stringifier)
+    public function __construct(private ShortUrlStringifierInterface $stringifier)
     {
     }
 
@@ -24,33 +20,8 @@ class ShortUrlDataTransformer implements DataTransformerInterface
     public function transform($shortUrl): array // phpcs:ignore
     {
         return [
-            'shortCode' => $shortUrl->getShortCode(),
             'shortUrl' => $this->stringifier->stringify($shortUrl),
-            'longUrl' => $shortUrl->getLongUrl(),
-            'dateCreated' => $shortUrl->getDateCreated()->toAtomString(),
-            'tags' => array_map(static fn (Tag $tag) => $tag->__toString(), $shortUrl->getTags()->toArray()),
-            'meta' => $this->buildMeta($shortUrl),
-            'domain' => $shortUrl->getDomain(),
-            'title' => $shortUrl->title(),
-            'crawlable' => $shortUrl->crawlable(),
-            'forwardQuery' => $shortUrl->forwardQuery(),
-            'visitsSummary' => VisitsSummary::fromTotalAndNonBots(
-                $shortUrl->getVisitsCount(),
-                $shortUrl->nonBotVisitsCount(),
-            ),
-        ];
-    }
-
-    private function buildMeta(ShortUrl $shortUrl): array
-    {
-        $validSince = $shortUrl->getValidSince();
-        $validUntil = $shortUrl->getValidUntil();
-        $maxVisits = $shortUrl->getMaxVisits();
-
-        return [
-            'validSince' => $validSince?->toAtomString(),
-            'validUntil' => $validUntil?->toAtomString(),
-            'maxVisits' => $maxVisits,
+            ...$shortUrl->toArray(),
         ];
     }
 }

--- a/module/Core/test/EventDispatcher/PublishingUpdatesGeneratorTest.php
+++ b/module/Core/test/EventDispatcher/PublishingUpdatesGeneratorTest.php
@@ -132,7 +132,7 @@ class PublishingUpdatesGeneratorTest extends TestCase
                 'maxVisits' => null,
             ],
             'domain' => null,
-            'title' => $shortUrl->title(),
+            'title' => 'The title',
             'crawlable' => false,
             'forwardQuery' => true,
             'visitsSummary' => VisitsSummary::fromTotalAndNonBots(0, 0),

--- a/module/Core/test/ShortUrl/ShortUrlServiceTest.php
+++ b/module/Core/test/ShortUrl/ShortUrlServiceTest.php
@@ -70,9 +70,11 @@ class ShortUrlServiceTest extends TestCase
         );
 
         self::assertSame($shortUrl, $result);
-        self::assertEquals($shortUrlEdit->validSince, $shortUrl->getValidSince());
-        self::assertEquals($shortUrlEdit->validUntil, $shortUrl->getValidUntil());
-        self::assertEquals($shortUrlEdit->maxVisits, $shortUrl->getMaxVisits());
+        ['validSince' => $since, 'validUntil' => $until, 'maxVisits' => $maxVisits] = $shortUrl->toArray()['meta'];
+
+        self::assertEquals($shortUrlEdit->validSince?->toAtomString(), $since);
+        self::assertEquals($shortUrlEdit->validUntil?->toAtomString(), $until);
+        self::assertEquals($shortUrlEdit->maxVisits, $maxVisits);
         self::assertEquals($shortUrlEdit->longUrl ?? $originalLongUrl, $shortUrl->getLongUrl());
     }
 


### PR DESCRIPTION
Get rid of most `ShortUrl` getters by moving the logic to convert to array to the entity itself.