### PR TITLE
Improve tags stats performance by using the new short_url_visits_counts table

### DIFF
--- a/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
+++ b/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
@@ -85,7 +85,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->from(ShortUrl::class, 's')
-            ->where('1=1');
+           ->where('1=1');
 
         $dateRange = $filtering->dateRange;
         if ($dateRange?->startDate !== null) {


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/1346

Change how visits amounts are calculated for tags with stats, so that it does a `SUM` of short_url_visits_counts` instad of a `COUNT` of `visits`.

This drastically improves performance, but it still takes as long even when only a subset of tags is returned.

Further work should be done to re-work the whole query.