### PR TITLE
Allow memory_limit to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
   This allows for a better traceability, as the logs generated during those jobs will have a matching UUID as the logs generated during the request the triggered the job.
 
+* [#2087](https://github.com/shlinkio/shlink/issues/2087) Allow `memory_limit` to be configured via the new `MEMORY_LIMIT` env var.
+
 ### Deprecated
 * *Nothing*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
   This allows for a better traceability, as the logs generated during those jobs will have a matching UUID as the logs generated during the request the triggered the job.
 
-* [#2087](https://github.com/shlinkio/shlink/issues/2087) Allow `memory_limit` to be configured via the new `MEMORY_LIMIT` env var.
+* [#2087](https://github.com/shlinkio/shlink/issues/2087) Allow `memory_limit` to be configured via the new `MEMORY_LIMIT` env var or configuration option.
 
 ### Deprecated
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "shlinkio/shlink-config": "^3.0",
         "shlinkio/shlink-event-dispatcher": "dev-main#a2a5d6f as 4.1",
         "shlinkio/shlink-importer": "^5.3.1",
-        "shlinkio/shlink-installer": "^9.0",
+        "shlinkio/shlink-installer": "dev-develop#164e23d as 9.1",
         "shlinkio/shlink-ip-geolocation": "^4.0",
         "shlinkio/shlink-json": "^1.1",
         "spiral/roadrunner": "^2023.3",

--- a/config/autoload/installer.global.php
+++ b/config/autoload/installer.global.php
@@ -12,6 +12,7 @@ return [
     'installer' => [
         'enabled_options' => [
             Option\Server\RuntimeConfigOption::class,
+            Option\Server\MemoryLimitConfigOption::class,
             Option\Database\DatabaseDriverConfigOption::class,
             Option\Database\DatabaseNameConfigOption::class,
             Option\Database\DatabaseHostConfigOption::class,

--- a/config/container.php
+++ b/config/container.php
@@ -12,6 +12,8 @@ chdir(dirname(__DIR__));
 
 require 'vendor/autoload.php';
 
+// Set a default memory limit, but allow custom values
+ini_set('memory_limit', EnvVars::MEMORY_LIMIT->loadFromEnv('512M'));
 // This is one of the first files loaded. Configure the timezone here
 date_default_timezone_set(EnvVars::TIMEZONE->loadFromEnv(date_default_timezone_get()));
 

--- a/data/infra/php.ini
+++ b/data/infra/php.ini
@@ -1,6 +1,5 @@
 display_errors=On
 error_reporting=-1
-memory_limit=-1
 log_errors_max_len=0
 zend.assertions=1
 assert.exception=1

--- a/docker/config/php.ini
+++ b/docker/config/php.ini
@@ -1,4 +1,3 @@
 log_errors_max_len=0
 zend.assertions=1
 assert.exception=1
-memory_limit=512M

--- a/module/Core/src/Config/EnvVars.php
+++ b/module/Core/src/Config/EnvVars.php
@@ -71,6 +71,7 @@ enum EnvVars: string
     case REDIRECT_APPEND_EXTRA_PATH = 'REDIRECT_APPEND_EXTRA_PATH';
     case TIMEZONE = 'TIMEZONE';
     case MULTI_SEGMENT_SLUGS_ENABLED = 'MULTI_SEGMENT_SLUGS_ENABLED';
+    case MEMORY_LIMIT = 'MEMORY_LIMIT';
 
     public function loadFromEnv(mixed $default = null): mixed
     {


### PR DESCRIPTION
Closes #2087

This PR adds a new config option/env var to customize the max allowed memory to be used by Shlink.