### PR TITLE
Fix custom slugs not being properly imported from bitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Fixed
+* [#2095](https://github.com/shlinkio/shlink/issues/2095) Fix custom slugs not being properly imported from bitly
 * Fix error when importing short URLs and visits from a Shlink 4.x instance
 
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "shlinkio/shlink-common": "dev-main#3cb0845 as 6.1",
         "shlinkio/shlink-config": "^3.0",
         "shlinkio/shlink-event-dispatcher": "dev-main#a2a5d6f as 4.1",
-        "shlinkio/shlink-importer": "^5.3.1",
+        "shlinkio/shlink-importer": "^5.3.2",
         "shlinkio/shlink-installer": "dev-develop#164e23d as 9.1",
         "shlinkio/shlink-ip-geolocation": "^4.0",
         "shlinkio/shlink-json": "^1.1",


### PR DESCRIPTION
Closes #2095 

Update shlink-importer, to take advantage of what was implemented in https://github.com/shlinkio/shlink-importer/pull/70, fixing the importing of custom slugs from bitly