### PR TITLE
Remove unneeded DISTINCT from list short URLs query

### DIFF
--- a/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
+++ b/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
@@ -42,7 +42,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
 
         $qb = $this->createListQueryBuilder($filtering);
         $qb->select(
-            'DISTINCT s AS shortUrl',
+            's AS shortUrl',
             '(' . $buildVisitsSubQuery('v', excludingBots: false) . ') AS ' . OrderableField::VISITS->value,
             '(' . $buildVisitsSubQuery('v2', excludingBots: true) . ') AS ' . OrderableField::NON_BOT_VISITS->value,
             // This is added only to have a consistent order by title between database engines


### PR DESCRIPTION
This is an optimization to the "list short URLs" query, which removes an unneeded `DISTINCT`.

This was found while testing other performance improvements highlighted by #2112 

While testing on a database with ~1M short URLs, removing the `DISTINCT` reduces the query execution time by 50%