### PR TITLE
Revert "Remove unneeded DISTINCT from list short URLs query"

### DIFF
--- a/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
+++ b/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
@@ -42,7 +42,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
 
         $qb = $this->createListQueryBuilder($filtering);
         $qb->select(
-            's AS shortUrl',
+            'DISTINCT s AS shortUrl',
             '(' . $buildVisitsSubQuery('v', excludingBots: false) . ') AS ' . OrderableField::VISITS->value,
             '(' . $buildVisitsSubQuery('v2', excludingBots: true) . ') AS ' . OrderableField::NON_BOT_VISITS->value,
             // This is added only to have a consistent order by title between database engines


### PR DESCRIPTION
Reverts shlinkio/shlink#2117

The `DISTINCT` is actually needed, but there's no test covering the combination in which it is.

When filtering short URLs by tags or by search term, the query needs to join with the tags table, in which case the results are not correct without the `DISTINCT`.

The right fix here would be something in the lines of:

1. Dynamically add `DISTINCT` only when strictly needed, to reduce the performance impact in some cases at least.
2. Change the way filtering by tag or by search term works. Perhaps using a subquery would work here, but that can introduce its own performance issues and also needs to be tested.

A test covering this case needs to be added.