### PR TITLE
Add logic for IP-based dynamic redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 ### Added
+* [#2120](https://github.com/shlinkio/shlink/issues/2120) Add new IP address condition for the dynamic rules redirections system.
+
+  The conditions allow you to define IP addresses to match as static IP (1.2.3.4), CIDR block (192.168.1.0/24) or wildcard pattern (1.2.\*.\*).
+
 * [#2018](https://github.com/shlinkio/shlink/issues/2018) Add option to allow all short URLs to be unconditionally crawlable in robots.txt, via `ROBOTS_ALLOW_ALL_SHORT_URLS=true` env var, or config option.
 * [#2109](https://github.com/shlinkio/shlink/issues/2109) Add option to customize user agents robots.txt, via `ROBOTS_USER_AGENTS=foo,bar,baz` env var, or config option.
 

--- a/docs/swagger/definitions/SetShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/SetShortUrlRedirectRule.json
@@ -15,8 +15,8 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["device", "language", "query-param"],
-            "description": "The type of the condition, which will condition the logic used to match it"
+            "enum": ["device", "language", "query-param", "ip-address"],
+            "description": "The type of the condition, which will determine the logic used to match it"
           },
           "matchKey":  {
             "type": ["string", "null"]

--- a/module/CLI/src/RedirectRule/RedirectRuleHandler.php
+++ b/module/CLI/src/RedirectRule/RedirectRuleHandler.php
@@ -108,6 +108,9 @@ class RedirectRuleHandler implements RedirectRuleHandlerInterface
                     $this->askMandatory('Query param name?', $io),
                     $this->askOptional('Query param value?', $io),
                 ),
+                RedirectConditionType::IP_ADDRESS => RedirectCondition::forIpAddress(
+                    $this->askMandatory('IP address, CIDR block or wildcard-pattern (1.2.*.*)', $io),
+                ),
             };
 
             $continue = $io->confirm('Do you want to add another condition?');

--- a/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
+++ b/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
@@ -116,6 +116,7 @@ class RedirectRuleHandlerTest extends TestCase
                 'Language to match?' => 'en-US',
                 'Query param name?' => 'foo',
                 'Query param value?' => 'bar',
+                'IP address, CIDR block or wildcard-pattern (1.2.*.*)' => '1.2.3.4',
                 default => '',
             },
         );
@@ -163,6 +164,7 @@ class RedirectRuleHandlerTest extends TestCase
             [RedirectCondition::forQueryParam('foo', 'bar'), RedirectCondition::forQueryParam('foo', 'bar')],
             true,
         ];
+        yield 'IP address' => [RedirectConditionType::IP_ADDRESS, [RedirectCondition::forIpAddress('1.2.3.4')]];
     }
 
     #[Test]

--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -14,6 +14,8 @@ use Jaybizzle\CrawlerDetect\CrawlerDetect;
 use Laminas\Filter\Word\CamelCaseToSeparator;
 use Laminas\Filter\Word\CamelCaseToUnderscore;
 use Laminas\InputFilter\InputFilter;
+use Psr\Http\Message\ServerRequestInterface;
+use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Common\Util\DateRange;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlMode;
 
@@ -272,4 +274,9 @@ function splitByComma(?string $value): array
     }
 
     return array_map(trim(...), explode(',', $value));
+}
+
+function ipAddressFromRequest(ServerRequestInterface $request): ?string
+{
+    return $request->getAttribute(IpAddressMiddlewareFactory::REQUEST_ATTR);
 }

--- a/module/Core/src/Exception/InvalidIpFormatException.php
+++ b/module/Core/src/Exception/InvalidIpFormatException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Exception;
+
+use function sprintf;
+
+class InvalidIpFormatException extends RuntimeException implements ExceptionInterface
+{
+    public static function fromInvalidIp(string $ipAddress): self
+    {
+        return new self(sprintf('Provided IP %s does not have the right format. Expected X.X.X.X', $ipAddress));
+    }
+}

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -5,14 +5,14 @@ namespace Shlinkio\Shlink\Core\RedirectRule\Entity;
 use JsonSerializable;
 use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Common\Entity\AbstractEntity;
-use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Core\Model\DeviceType;
 use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
 use Shlinkio\Shlink\Core\RedirectRule\Model\Validation\RedirectRulesInputFilter;
-
 use Shlinkio\Shlink\Core\Util\IpAddressUtils;
+
 use function Shlinkio\Shlink\Core\acceptLanguageToLocales;
 use function Shlinkio\Shlink\Core\ArrayUtils\some;
+use function Shlinkio\Shlink\Core\ipAddressFromRequest;
 use function Shlinkio\Shlink\Core\normalizeLocale;
 use function Shlinkio\Shlink\Core\splitLocale;
 use function sprintf;
@@ -114,7 +114,7 @@ class RedirectCondition extends AbstractEntity implements JsonSerializable
 
     private function matchesRemoteIpAddress(ServerRequestInterface $request): bool
     {
-        $remoteAddress = $request->getAttribute(IpAddressMiddlewareFactory::REQUEST_ATTR);
+        $remoteAddress = ipAddressFromRequest($request);
         return $remoteAddress !== null && IpAddressUtils::ipAddressMatchesGroups($remoteAddress, [$this->matchValue]);
     }
 

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -7,4 +7,5 @@ enum RedirectConditionType: string
     case DEVICE = 'device';
     case LANGUAGE = 'language';
     case QUERY_PARAM = 'query-param';
+    case IP_ADDRESS = 'ip-address';
 }

--- a/module/Core/src/Util/IpAddressUtils.php
+++ b/module/Core/src/Util/IpAddressUtils.php
@@ -26,7 +26,7 @@ final class IpAddressUtils
      * Matching will happen as follows:
      *  * Static IP address -> strict equality with provided IP address.
      *  * CIDR block -> provided IP address is part of that block.
-     *  * Wildcard -> static parts match the corresponding ones in provided IP address.
+     *  * Wildcard pattern -> static parts match the corresponding ones in provided IP address.
      *
      * @param string[] $groups
      * @throws InvalidIpFormatException

--- a/module/Core/src/Util/IpAddressUtils.php
+++ b/module/Core/src/Util/IpAddressUtils.php
@@ -18,6 +18,11 @@ use function str_contains;
 
 final class IpAddressUtils
 {
+    public static function isStaticIpCidrOrWildcard(string $candidate): bool
+    {
+        return self::candidateToRange($candidate, ['0', '0', '0', '0']) !== null;
+    }
+
     /**
      * Checks if an IP address matches any of provided groups.
      * Every group can be a static IP address (100.200.80.40), a CIDR block (192.168.10.0/24) or a wildcard pattern
@@ -40,15 +45,29 @@ final class IpAddressUtils
 
         $ipAddressParts = explode('.', $ipAddress);
 
-        return some($groups, function (string $value) use ($ip, $ipAddressParts): bool {
-            $range = str_contains($value, '*')
-                ? self::parseValueWithWildcards($value, $ipAddressParts)
-                : Factory::parseRangeString($value);
-
-            return $range !== null && $ip->matches($range);
+        return some($groups, function (string $group) use ($ip, $ipAddressParts): bool {
+            $range = self::candidateToRange($group, $ipAddressParts);
+            return $range !== null && $range->contains($ip);
         });
     }
 
+    /**
+     * Convert a static IP, CIDR block or wildcard pattern into a Range object
+     *
+     * @param string[] $ipAddressParts
+     */
+    private static function candidateToRange(string $candidate, array $ipAddressParts): ?RangeInterface
+    {
+        return str_contains($candidate, '*')
+            ? self::parseValueWithWildcards($candidate, $ipAddressParts)
+            : Factory::parseRangeString($candidate);
+    }
+
+    /**
+     * Try to generate an IP range from a wildcard pattern.
+     * Factory::parseRangeString can usually do this automatically, but only if wildcards are at the end. This also
+     * covers cases where wildcards are in between.
+     */
     private static function parseValueWithWildcards(string $value, array $ipAddressParts): ?RangeInterface
     {
         $octets = explode('.', $value);

--- a/module/Core/src/Util/IpAddressUtils.php
+++ b/module/Core/src/Util/IpAddressUtils.php
@@ -14,8 +14,9 @@ use function array_map;
 use function explode;
 use function implode;
 use function Shlinkio\Shlink\Core\ArrayUtils\some;
+use function str_contains;
 
-class IpAddressUtils
+final class IpAddressUtils
 {
     /**
      * Checks if an IP address matches any of provided groups.

--- a/module/Core/src/Util/IpAddressUtils.php
+++ b/module/Core/src/Util/IpAddressUtils.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Util;
+
+use IPLib\Address\IPv4;
+use IPLib\Factory;
+use IPLib\Range\RangeInterface;
+use Shlinkio\Shlink\Core\Exception\InvalidIpFormatException;
+
+use function array_keys;
+use function array_map;
+use function explode;
+use function implode;
+use function Shlinkio\Shlink\Core\ArrayUtils\some;
+
+class IpAddressUtils
+{
+    /**
+     * Checks if an IP address matches any of provided groups.
+     * Every group can be a static IP address (100.200.80.40), a CIDR block (192.168.10.0/24) or a wildcard pattern
+     * (11.22.*.*).
+     *
+     * Matching will happen as follows:
+     *  * Static IP address -> strict equality with provided IP address.
+     *  * CIDR block -> provided IP address is part of that block.
+     *  * Wildcard -> static parts match the corresponding ones in provided IP address.
+     *
+     * @param string[] $groups
+     * @throws InvalidIpFormatException
+     */
+    public static function ipAddressMatchesGroups(string $ipAddress, array $groups): bool
+    {
+        $ip = IPv4::parseString($ipAddress);
+        if ($ip === null) {
+            throw InvalidIpFormatException::fromInvalidIp($ipAddress);
+        }
+
+        $ipAddressParts = explode('.', $ipAddress);
+
+        return some($groups, function (string $value) use ($ip, $ipAddressParts): bool {
+            $range = str_contains($value, '*')
+                ? self::parseValueWithWildcards($value, $ipAddressParts)
+                : Factory::parseRangeString($value);
+
+            return $range !== null && $ip->matches($range);
+        });
+    }
+
+    private static function parseValueWithWildcards(string $value, array $ipAddressParts): ?RangeInterface
+    {
+        $octets = explode('.', $value);
+        $keys = array_keys($octets);
+
+        // Replace wildcard parts with the corresponding ones from the remote address
+        return Factory::parseRangeString(
+            implode('.', array_map(
+                fn (string $part, int $index) => $part === '*' ? $ipAddressParts[$index] : $part,
+                $octets,
+                $keys,
+            )),
+        );
+    }
+}

--- a/module/Core/src/Visit/Model/Visitor.php
+++ b/module/Core/src/Visit/Model/Visitor.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Shlinkio\Shlink\Core\Visit\Model;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Core\Options\TrackingOptions;
 
+use function Shlinkio\Shlink\Core\ipAddressFromRequest;
 use function Shlinkio\Shlink\Core\isCrawler;
 use function substr;
 
@@ -46,7 +46,7 @@ final class Visitor
         return new self(
             $request->getHeaderLine('User-Agent'),
             $request->getHeaderLine('Referer'),
-            $request->getAttribute(IpAddressMiddlewareFactory::REQUEST_ATTR),
+            ipAddressFromRequest($request),
             $request->getUri()->__toString(),
         );
     }

--- a/module/Core/src/Visit/RequestTracker.php
+++ b/module/Core/src/Visit/RequestTracker.php
@@ -7,13 +7,14 @@ namespace Shlinkio\Shlink\Core\Visit;
 use Fig\Http\Message\RequestMethodInterface;
 use Mezzio\Router\Middleware\ImplicitHeadMiddleware;
 use Psr\Http\Message\ServerRequestInterface;
-use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Core\ErrorHandler\Model\NotFoundType;
 use Shlinkio\Shlink\Core\Exception\InvalidIpFormatException;
 use Shlinkio\Shlink\Core\Options\TrackingOptions;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\Util\IpAddressUtils;
 use Shlinkio\Shlink\Core\Visit\Model\Visitor;
+
+use function Shlinkio\Shlink\Core\ipAddressFromRequest;
 
 readonly class RequestTracker implements RequestTrackerInterface, RequestMethodInterface
 {
@@ -53,7 +54,7 @@ readonly class RequestTracker implements RequestTrackerInterface, RequestMethodI
             return false;
         }
 
-        $remoteAddr = $request->getAttribute(IpAddressMiddlewareFactory::REQUEST_ATTR);
+        $remoteAddr = ipAddressFromRequest($request);
         if ($this->shouldDisableTrackingFromAddress($remoteAddr)) {
             return false;
         }

--- a/module/Core/test-api/Action/RedirectTest.php
+++ b/module/Core/test-api/Action/RedirectTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use Shlinkio\Shlink\TestUtils\ApiTest\ApiTestCase;
 
+use function sprintf;
+
 use const ShlinkioTest\Shlink\ANDROID_USER_AGENT;
 use const ShlinkioTest\Shlink\DESKTOP_USER_AGENT;
 use const ShlinkioTest\Shlink\IOS_USER_AGENT;
@@ -86,6 +88,16 @@ class RedirectTest extends ApiTestCase
             ],
             'https://blog.alejandrocelaya.com/2017/12/09/acmailer-7-0-the-most-important-release-in-a-long-time/',
         ];
+
+        $clientDetection = require __DIR__ . '/../../../../config/autoload/client-detection.global.php';
+        foreach ($clientDetection['ip_address_resolution']['headers_to_inspect'] as $header) {
+            yield sprintf('rule: IP address in "%s" header', $header) => [
+                [
+                    RequestOptions::HEADERS => [$header => '1.2.3.4'],
+                ],
+                'https://example.com/static-ip-address',
+            ];
+        }
     }
 
     /**

--- a/module/Core/test/Exception/InvalidIpFormatExceptionTest.php
+++ b/module/Core/test/Exception/InvalidIpFormatExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Core\Exception;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Core\Exception\InvalidIpFormatException;
+
+class InvalidIpFormatExceptionTest extends TestCase
+{
+    #[Test]
+    public function fromInvalidIp(): void
+    {
+        $e = InvalidIpFormatException::fromInvalidIp('invalid');
+        self::assertEquals('Provided IP invalid does not have the right format. Expected X.X.X.X', $e->getMessage());
+    }
+}

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -6,6 +6,7 @@ use Laminas\Diactoros\ServerRequestFactory;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Core\Model\DeviceType;
 use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
 
@@ -28,19 +29,19 @@ class RedirectConditionTest extends TestCase
     }
 
     #[Test]
-    #[TestWith([null, '', false])] // no accept language
-    #[TestWith(['', '', false])] // empty accept language
-    #[TestWith(['*', '', false])] // wildcard accept language
-    #[TestWith(['en', 'en', true])] // single language match
-    #[TestWith(['es, en,fr', 'en', true])] // multiple languages match
-    #[TestWith(['es, en-US,fr', 'EN', true])] // multiple locales match
-    #[TestWith(['es_ES', 'es-ES', true])] // single locale match
-    #[TestWith(['en-US,es-ES;q=0.6', 'es-ES', false])] // too low quality
-    #[TestWith(['en-US,es-ES;q=0.9', 'es-ES', true])] // quality high enough
-    #[TestWith(['en-UK', 'en-uk', true])] // different casing match
-    #[TestWith(['en-UK', 'en', true])] // only lang
-    #[TestWith(['es-AR', 'en', false])] // different only lang
-    #[TestWith(['fr', 'fr-FR', false])] // less restrictive matching locale
+    #[TestWith([null, '', false], 'no accept language')]
+    #[TestWith(['', '', false], 'empty accept language')]
+    #[TestWith(['*', '', false], 'wildcard accept language')]
+    #[TestWith(['en', 'en', true], 'single language match')]
+    #[TestWith(['es, en,fr', 'en', true], 'multiple languages match')]
+    #[TestWith(['es, en-US,fr', 'EN', true], 'multiple locales match')]
+    #[TestWith(['es_ES', 'es-ES', true], 'single locale match')]
+    #[TestWith(['en-US,es-ES;q=0.6', 'es-ES', false], 'too low quality')]
+    #[TestWith(['en-US,es-ES;q=0.9', 'es-ES', true], 'quality high enough')]
+    #[TestWith(['en-UK', 'en-uk', true], 'different casing match')]
+    #[TestWith(['en-UK', 'en', true], 'only lang')]
+    #[TestWith(['es-AR', 'en', false], 'different only lang')]
+    #[TestWith(['fr', 'fr-FR', false], 'less restrictive matching locale')]
     public function matchesLanguage(?string $acceptLanguage, string $value, bool $expected): void
     {
         $request = ServerRequestFactory::fromGlobals();
@@ -69,6 +70,26 @@ class RedirectConditionTest extends TestCase
         }
 
         $result = RedirectCondition::forDevice($value)->matchesRequest($request);
+
+        self::assertEquals($expected, $result);
+    }
+
+    #[Test]
+    #[TestWith([null, '1.2.3.4', false], 'no remote IP address')]
+    #[TestWith(['1.2.3.4', '1.2.3.4', true], 'static IP address match')]
+    #[TestWith(['4.3.2.1', '1.2.3.4', false], 'no static IP address match')]
+    #[TestWith(['192.168.1.35', '192.168.1.0/24', true], 'CIDR block match')]
+    #[TestWith(['1.2.3.4', '192.168.1.0/24', false], 'no CIDR block match')]
+    #[TestWith(['192.168.1.35', '192.168.1.*', true], 'wildcard pattern match')]
+    #[TestWith(['1.2.3.4', '192.168.1.*', false], 'no wildcard pattern match')]
+    public function matchesRemoteIpAddress(?string $remoteIp, string $ipToMatch, bool $expected): void
+    {
+        $request = ServerRequestFactory::fromGlobals();
+        if ($remoteIp !== null) {
+            $request = $request->withAttribute(IpAddressMiddlewareFactory::REQUEST_ATTR, $remoteIp);
+        }
+
+        $result = RedirectCondition::forIpAddress($ipToMatch)->matchesRequest($request);
 
         self::assertEquals($expected, $result);
     }

--- a/module/Core/test/RedirectRule/Model/RedirectRulesDataTest.php
+++ b/module/Core/test/RedirectRule/Model/RedirectRulesDataTest.php
@@ -51,9 +51,76 @@ class RedirectRulesDataTest extends TestCase
             ],
         ],
     ]]])]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => 'not an IP address',
+                ],
+            ],
+        ],
+    ]]])]
     public function throwsWhenProvidedDataIsInvalid(array $invalidData): void
     {
         $this->expectException(ValidationException::class);
         RedirectRulesData::fromRawData($invalidData);
+    }
+
+    #[Test]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => '1.2.3.4',
+                ],
+            ],
+        ],
+    ]]], 'static IP')]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => '1.2.3.0/24',
+                ],
+            ],
+        ],
+    ]]], 'CIDR block')]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => '1.2.3.*',
+                ],
+            ],
+        ],
+    ]]], 'IP wildcard pattern')]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => '1.2.*.4',
+                ],
+            ],
+        ],
+    ]]], 'in-between IP wildcard pattern')]
+    public function allowsValidDataToBeSet(array $validData): void
+    {
+        $result = RedirectRulesData::fromRawData($validData);
+        self::assertEquals($result->rules, $validData['redirectRules']);
     }
 }

--- a/module/Core/test/Util/IpAddressUtilsTest.php
+++ b/module/Core/test/Util/IpAddressUtilsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkioTest\Shlink\Core\Util;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Shlinkio\Shlink\Core\Util\IpAddressUtils;
+
+class IpAddressUtilsTest extends TestCase
+{
+    #[Test]
+    #[TestWith(['', false], 'empty')]
+    #[TestWith(['invalid', false], 'invalid')]
+    #[TestWith(['1.2.3.4', true], 'static IP')]
+    #[TestWith(['456.2.385.4', false], 'invalid IP')]
+    #[TestWith(['192.168.1.0/24', true], 'CIDR block')]
+    #[TestWith(['1.2.*.*', true], 'wildcard pattern')]
+    #[TestWith(['1.2.*.1', true], 'in-between wildcard pattern')]
+    public function isStaticIpCidrOrWildcardReturnsExpectedResult(string $candidate, bool $expected): void
+    {
+        self::assertEquals($expected, IpAddressUtils::isStaticIpCidrOrWildcard($candidate));
+    }
+}

--- a/module/Core/test/Visit/RequestTrackerTest.php
+++ b/module/Core/test/Visit/RequestTrackerTest.php
@@ -93,6 +93,21 @@ class RequestTrackerTest extends TestCase
     }
 
     #[Test]
+    public function trackingHappensOverShortUrlsWhenRemoteAddressIsInvalid(): void
+    {
+        $shortUrl = ShortUrl::withLongUrl(self::LONG_URL);
+        $this->visitsTracker->expects($this->once())->method('track')->with(
+            $shortUrl,
+            $this->isInstanceOf(Visitor::class),
+        );
+
+        $this->requestTracker->trackIfApplicable($shortUrl, ServerRequestFactory::fromGlobals()->withAttribute(
+            IpAddressMiddlewareFactory::REQUEST_ATTR,
+            'invalid',
+        ));
+    }
+
+    #[Test]
     public function baseUrlErrorIsTracked(): void
     {
         $this->notFoundType->expects($this->once())->method('isBaseUrl')->willReturn(true);

--- a/module/Rest/test-api/Action/ListRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/ListRedirectRulesTest.php
@@ -87,6 +87,17 @@ class ListRedirectRulesTest extends ApiTestCase
                 ],
             ],
         ],
+        [
+            'longUrl' => 'https://example.com/static-ip-address',
+            'priority' => 6,
+            'conditions' => [
+                [
+                    'type' => 'ip-address',
+                    'matchKey' => null,
+                    'matchValue' => '1.2.3.4',
+                ],
+            ],
+        ],
     ]])]
     public function returnsListOfRulesForShortUrl(string $shortCode, array $expectedRules): void
     {

--- a/module/Rest/test-api/Action/SetRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/SetRedirectRulesTest.php
@@ -25,7 +25,7 @@ class SetRedirectRulesTest extends ApiTestCase
     ];
 
     #[Test]
-    public function errorIsReturnedWhenInvalidUrlProvided(): void
+    public function errorIsReturnedWhenInvalidUrlIsProvided(): void
     {
         $response = $this->callApiWithKey(self::METHOD_POST, '/short-urls/invalid/redirect-rules');
         $payload = $this->getJsonResponsePayload($response);
@@ -39,16 +39,67 @@ class SetRedirectRulesTest extends ApiTestCase
     }
 
     #[Test]
-    public function errorIsReturnedWhenInvalidDataProvided(): void
-    {
-        $response = $this->callApiWithKey(self::METHOD_POST, '/short-urls/abc123/redirect-rules', [
-            RequestOptions::JSON => [
-                'redirectRules' => [
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'invalid',
+            ],
+        ],
+    ]], 'invalid long URL')]
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'https://example.com',
+                'conditions' => 'foo',
+            ],
+        ],
+    ]], 'non-array conditions')]
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'https://example.com',
+                'conditions' => [
                     [
-                        'longUrl' => 'invalid',
+                        'type' => 'invalid',
+                        'matchKey' => null,
+                        'matchValue' => 'foo',
                     ],
                 ],
             ],
+        ],
+    ]], 'invalid condition type')]
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'https://example.com',
+                'conditions' => [
+                    [
+                        'type' => 'device',
+                        'matchValue' => 'invalid-device',
+                        'matchKey' => null,
+                    ],
+                ],
+            ],
+        ],
+    ]], 'invalid device type')]
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'https://example.com',
+                'conditions' => [
+                    [
+                        'type' => 'ip-address',
+                        'matchKey' => null,
+                        'matchValue' => 'not an IP address',
+                    ],
+                ],
+            ],
+        ],
+    ]], 'invalid IP address')]
+    public function errorIsReturnedWhenInvalidDataIsProvided(array $bodyPayload): void
+    {
+        $response = $this->callApiWithKey(self::METHOD_POST, '/short-urls/abc123/redirect-rules', [
+            RequestOptions::JSON => $bodyPayload,
         ]);
         $payload = $this->getJsonResponsePayload($response);
 

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -70,6 +70,14 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
         );
         $manager->persist($iosRule);
 
+        $ipAddressRule = new ShortUrlRedirectRule(
+            shortUrl: $defShortUrl,
+            priority: 6,
+            longUrl: 'https://example.com/static-ip-address',
+            conditions: new ArrayCollection([RedirectCondition::forIpAddress('1.2.3.4')]),
+        );
+        $manager->persist($ipAddressRule);
+
         $manager->flush();
     }
 }


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink/issues/2120

Allow redirect rule conditions based on visitors IP addresses. Condition values can be static IP addresses (100.200.80.40), CIDR blocks (192.168.10.0/24) or wildcard patterns (11.22.\*.\*).

Alternative implementation to https://github.com/shlinkio/shlink/pull/2121, with the next differences:

* The logic to check if the IP address matches the rule pattern, is shared with the existing logic to check if current IP address matches the values provided in `DISABLE_TRACKING_FROM`.
* Every condition will allow only one Ip address to match, instead of a comma-separated list. If more than one group should redirect to the same place, users will simply have to create a few consecutive rules.
* Validation is done in `RedirectRulesInputFilter`.

### TODO

- [x] API test.
- [x] IP address/CIDR block/Wildcard pattern validation.
- [x] API spec.