### PR TITLE
Fix `MEMORY_LIMIT` being ignored when provided as installer config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [4.2.1] - 2024-10-04
 ### Added
 * [#2183](https://github.com/shlinkio/shlink/issues/2183) Redis database index to be used can now be specified in the connection URI path, and Shlink will honor it.
 
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#2201](https://github.com/shlinkio/shlink/issues/2201) Fix `MEMORY_LIMIT` option being ignored when provided via installer options.
 
 
 ## [4.2.0] - 2024-08-11

--- a/config/container.php
+++ b/config/container.php
@@ -12,8 +12,6 @@ chdir(dirname(__DIR__));
 
 require 'vendor/autoload.php';
 
-// Set a default memory limit, but allow custom values
-ini_set('memory_limit', EnvVars::MEMORY_LIMIT->loadFromEnv('512M'));
 // This is one of the first files loaded. Configure the timezone here
 date_default_timezone_set(EnvVars::TIMEZONE->loadFromEnv(date_default_timezone_get()));
 
@@ -25,6 +23,10 @@ if (! class_exists(LOCAL_LOCK_FACTORY)) {
 
 return (static function (): ServiceManager {
     $config = require __DIR__ . '/config.php';
+
+    // Set a default memory limit right after loading config, to ensure installer config has been promoted as env vars
+    ini_set('memory_limit', EnvVars::MEMORY_LIMIT->loadFromEnv('512M'));
+
     $container = new ServiceManager($config['dependencies']);
     $container->setService('config', $config);
 

--- a/config/container.php
+++ b/config/container.php
@@ -24,7 +24,7 @@ if (! class_exists(LOCAL_LOCK_FACTORY)) {
 return (static function (): ServiceManager {
     $config = require __DIR__ . '/config.php';
 
-    // Set a default memory limit right after loading config, to ensure installer config has been promoted as env vars
+    // Set memory limit right after loading config, to ensure installer config has been promoted as env vars
     ini_set('memory_limit', EnvVars::MEMORY_LIMIT->loadFromEnv('512M'));
 
     $container = new ServiceManager($config['dependencies']);


### PR DESCRIPTION
Fixes #2201 

Make `MEMORY_LIMIT` option be read as env var after config has been loaded, to make sure config from the installer has been promoted as env vars at that point.