### PR TITLE
Promote installer config options as env vars explicitly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ramsey/uuid": "^4.7",
         "shlinkio/doctrine-specification": "^2.1.1",
         "shlinkio/shlink-common": "^6.3",
-        "shlinkio/shlink-config": "^3.0",
+        "shlinkio/shlink-config": "dev-main#76a96ee as 3.1",
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",
         "shlinkio/shlink-installer": "^9.2",

--- a/config/config.php
+++ b/config/config.php
@@ -8,18 +8,13 @@ use Laminas\ConfigAggregator;
 use Laminas\Diactoros;
 use Mezzio;
 use Mezzio\ProblemDetails;
-use Shlinkio\Shlink\Config\ConfigAggregator\EnvVarLoaderProvider;
 
 use function Shlinkio\Shlink\Config\env;
-use function Shlinkio\Shlink\Core\enumValues;
 
 $isTestEnv = env('APP_ENV') === 'test';
 
 return (new ConfigAggregator\ConfigAggregator(
     providers: [
-        ! $isTestEnv
-            ? new EnvVarLoaderProvider('config/params/generated_config.php', enumValues(Core\Config\EnvVars::class))
-            : new ConfigAggregator\ArrayProvider([]),
         Mezzio\ConfigProvider::class,
         Mezzio\Router\ConfigProvider::class,
         Mezzio\Router\FastRouteRouter\ConfigProvider::class,


### PR DESCRIPTION
https://github.com/shlinkio/shlink/issues/2201 showed that the fact that loading the config also promotes installer options as env vars is something easy to forget.

This PR changes that so that promoting config options is done explicitly, in case any of them needs to be read anywhere outside of config files, reducing the changes of reading the env var too early.

Closes #2208 