### PR TITLE
Ensure query parameters are preserved verbatim when forwarded to long URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#2213](https://github.com/shlinkio/shlink/issues/2213) Fix spaces being replaced with underscores in query parameter names, when forwarded from short URL to long URL.
 
 
 ## [4.2.1] - 2024-10-04

--- a/config/autoload/rabbit.local.php.dist
+++ b/config/autoload/rabbit.local.php.dist
@@ -7,7 +7,7 @@ return [
     'rabbitmq' => [
         'enabled' => true,
         'host' => 'shlink_rabbitmq',
-        'port' => '5672',
+        'port' => 5672,
         'user' => 'rabbit',
         'password' => 'rabbit',
     ],

--- a/module/Core/src/ShortUrl/Helper/ShortUrlRedirectionBuilder.php
+++ b/module/Core/src/ShortUrl/Helper/ShortUrlRedirectionBuilder.php
@@ -28,10 +28,14 @@ readonly class ShortUrlRedirectionBuilder implements ShortUrlRedirectionBuilderI
         ?string $extraPath = null,
     ): string {
         $uri = new Uri($this->redirectionResolver->resolveLongUrl($shortUrl, $request));
-        $currentQuery = $request->getQueryParams();
         $shouldForwardQuery = $shortUrl->forwardQuery();
         $baseQueryString = $uri->getQuery();
         $basePath = $uri->getPath();
+
+        // Get current query by manually parsing query string, instead of using $request->getQueryParams().
+        // That prevents some weird PHP logic in which some characters in param names are converted to ensure resulting
+        // names are valid variable names.
+        $currentQuery = Query::parse($request->getUri()->getQuery());
 
         return $uri
             ->withQuery($shouldForwardQuery ? $this->resolveQuery($baseQueryString, $currentQuery) : $baseQueryString)

--- a/module/Core/test-api/Action/RedirectTest.php
+++ b/module/Core/test-api/Action/RedirectTest.php
@@ -122,4 +122,22 @@ class RedirectTest extends ApiTestCase
         self::assertEquals(302, $response->getStatusCode());
         self::assertEquals($longUrl, $response->getHeaderLine('Location'));
     }
+
+    #[Test]
+    public function queryParametersAreProperlyForwarded(): void
+    {
+        $slug = 'forward-query-params';
+        $this->callApiWithKey('POST', '/short-urls', [
+            RequestOptions::JSON => [
+                'longUrl' => 'https://example.com',
+                'customSlug' => $slug,
+                'forwardQuery' => true,
+            ],
+        ]);
+
+        $response = $this->callShortUrl($slug, [RequestOptions::QUERY => ['foo bar' => '123']]);
+
+        self::assertEquals(302, $response->getStatusCode());
+        self::assertEquals('https://example.com?foo%20bar=123', $response->getHeaderLine('Location'));
+    }
 }


### PR DESCRIPTION
Closes #2213 

When merging request query params with the long URL onces, right before redirecting, this PR makes the request ones are parsed manually so that they are preserved verbatim.

By using `$request->getQueryParams()` we were getting affected by a historical decisions in PHP, where query params are promoted as vars, and therefore, characters not allowed in variable names (like spaces) where replaced by something else.

Since we do not rely in this side effect, manually parsing the query string prevents this behavior and preserves params with "special" chars verbatim.