### PR TITLE
Update to shlink-config 3.2.1, which fixes skipping config options with null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.2.3] - 2024-10-17
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2225](https://github.com/shlinkio/shlink/issues/2225) Fix regression introduced in v4.2.2, making config options with `null` value to be promoted as env vars with value `''`, instead of being skipped.
+
+
 ## [4.2.2] - 2024-10-14
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ramsey/uuid": "^4.7",
         "shlinkio/doctrine-specification": "^2.1.1",
         "shlinkio/shlink-common": "^6.3",
-        "shlinkio/shlink-config": "^3.2",
+        "shlinkio/shlink-config": "^3.2.1",
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",
         "shlinkio/shlink-installer": "^9.2",

--- a/module/Core/src/Config/EnvVars.php
+++ b/module/Core/src/Config/EnvVars.php
@@ -97,6 +97,23 @@ enum EnvVars: string
         return env($this->value) ?? $this->loadFromFileEnv() ?? $this->defaultValue();
     }
 
+    /**
+     * Checks if an equivalent environment variable exists with the `_FILE` suffix. If so, it loads its value as a file,
+     * reads it, and returns its contents.
+     * This is useful when loading Shlink with docker compose and using secrets.
+     * See https://docs.docker.com/compose/use-secrets/
+     */
+    private function loadFromFileEnv(): string|int|bool|null
+    {
+        $file = env(sprintf('%s_FILE', $this->value));
+        if ($file === null || ! is_file($file)) {
+            return null;
+        }
+
+        $content = file_get_contents($file);
+        return $content ? parseEnvVar($content) : null;
+    }
+
     private function defaultValue(): string|int|bool|null
     {
         return match ($this) {
@@ -151,23 +168,6 @@ enum EnvVars: string
 
             default => null,
         };
-    }
-
-    /**
-     * Checks if an equivalent environment variable exists with the `_FILE` suffix. If so, it loads its value as a file,
-     * reads it, and returns its contents.
-     * This is useful when loading Shlink with docker compose and using secrets.
-     * See https://docs.docker.com/compose/use-secrets/
-     */
-    private function loadFromFileEnv(): string|int|bool|null
-    {
-        $file = env(sprintf('%s_FILE', $this->value));
-        if ($file === null || ! is_file($file)) {
-            return null;
-        }
-
-        $content = file_get_contents($file);
-        return $content ? parseEnvVar($content) : null;
     }
 
     public function existsInEnv(): bool


### PR DESCRIPTION
Closes #2225 

Update to shlink-config 3.2.1, which includes [a fix](https://github.com/shlinkio/shlink-config/pull/38) to skip config options with value `null` when promoting them to env vars.