### PR TITLE
Feature/rules flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#2207](https://github.com/shlinkio/shlink/issues/2207) Add `hasRedirectRules` flag to short URL API model. This flag tells if a specific short URL has any redirect rules attached to it.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [4.2.4] - 2024-10-27
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "pagerfanta/core": "^3.8",
         "ramsey/uuid": "^4.7",
         "shlinkio/doctrine-specification": "^2.1.1",
-        "shlinkio/shlink-common": "^6.4",
+        "shlinkio/shlink-common": "dev-main#5fbe58c as 6.5",
         "shlinkio/shlink-config": "^3.3",
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",

--- a/docs/async-api/async-api.json
+++ b/docs/async-api/async-api.json
@@ -141,6 +141,14 @@
                     "crawlable": {
                         "type": "boolean",
                         "description": "Tells if this URL will be included as 'Allow' in Shlink's robots.txt."
+                    },
+                    "forwardQuery": {
+                        "type": "boolean",
+                        "description": "Tells if this URL will forward the query params to the long URL when visited, as explained in [the docs](https://shlink.io/documentation/some-features/#query-params-forwarding)."
+                    },
+                    "hasRedirectRules": {
+                        "type": "boolean",
+                        "description": "Whether this short URL has redirect rules attached to it or not. Use [this endpoint](https://api-spec.shlink.io/#/Redirect%20rules/listShortUrlRedirectRules) to get the actual list of rules."
                     }
                 },
                 "example": {
@@ -164,7 +172,9 @@
                     },
                     "domain": "example.com",
                     "title": "The title",
-                    "crawlable": false
+                    "crawlable": false,
+                    "forwardQuery": false,
+                    "hasRedirectRules": true
                 }
             },
             "ShortUrlMeta": {

--- a/docs/swagger/definitions/ShortUrl.json
+++ b/docs/swagger/definitions/ShortUrl.json
@@ -11,7 +11,8 @@
         "domain",
         "title",
         "crawlable",
-        "forwardQuery"
+        "forwardQuery",
+        "hasRedirectRules"
     ],
     "properties": {
         "shortCode": {
@@ -59,6 +60,10 @@
         "forwardQuery": {
             "type": "boolean",
             "description": "Tells if this URL will forward the query params to the long URL when visited, as explained in [the docs](https://shlink.io/documentation/some-features/#query-params-forwarding)."
+        },
+        "hasRedirectRules": {
+            "type": "boolean",
+            "description": "Whether this short URL has redirect rules attached to it or not. Use [this endpoint](https://api-spec.shlink.io/#/Redirect%20rules/listShortUrlRedirectRules) to get the actual list of rules."
         }
     }
 }

--- a/docs/swagger/paths/v1_short-urls.json
+++ b/docs/swagger/paths/v1_short-urls.json
@@ -180,7 +180,9 @@
                                         },
                                         "domain": null,
                                         "title": "Welcome to Steam",
-                                        "crawlable": false
+                                        "crawlable": false,
+                                        "forwardQuery": true,
+                                        "hasRedirectRules": true
                                     },
                                     {
                                         "shortCode": "12Kb3",
@@ -202,7 +204,9 @@
                                         },
                                         "domain":  null,
                                         "title": null,
-                                        "crawlable": false
+                                        "crawlable": false,
+                                        "forwardQuery": true,
+                                        "hasRedirectRules": false
                                     },
                                     {
                                         "shortCode": "123bA",
@@ -222,7 +226,9 @@
                                         },
                                         "domain":  "example.com",
                                         "title": null,
-                                        "crawlable": false
+                                        "crawlable": false,
+                                        "forwardQuery": false,
+                                        "hasRedirectRules": true
                                     }
                                 ],
                                 "pagination": {
@@ -337,7 +343,9 @@
                             },
                             "domain": null,
                             "title": null,
-                            "crawlable": false
+                            "crawlable": false,
+                            "forwardQuery": true,
+                            "hasRedirectRules": false
                         }
                     }
                 }

--- a/docs/swagger/paths/v1_short-urls_shorten.json
+++ b/docs/swagger/paths/v1_short-urls_shorten.json
@@ -72,7 +72,9 @@
                             },
                             "domain": null,
                             "title": null,
-                            "crawlable": false
+                            "crawlable": false,
+                            "forwardQuery": true,
+                            "hasRedirectRules": false
                         }
                     },
                     "text/plain": {

--- a/docs/swagger/paths/v1_short-urls_{shortCode}.json
+++ b/docs/swagger/paths/v1_short-urls_{shortCode}.json
@@ -50,7 +50,9 @@
                             },
                             "domain": null,
                             "title": null,
-                            "crawlable": false
+                            "crawlable": false,
+                            "forwardQuery": true,
+                            "hasRedirectRules": true
                         }
                     }
                 }
@@ -163,7 +165,9 @@
                             },
                             "domain": null,
                             "title": "Shlink - The URL shortener",
-                            "crawlable": false
+                            "crawlable": false,
+                            "forwardQuery": false,
+                            "hasRedirectRules": true
                         }
                     }
                 }

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
@@ -110,4 +110,9 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->columnName('forward_query')
             ->option('default', true)
             ->build();
+
+    $builder->createOneToMany('redirectRules', RedirectRule\Entity\ShortUrlRedirectRule::class)
+            ->mappedBy('shortUrl')
+            ->fetchExtraLazy()
+            ->build();
 };

--- a/module/Core/src/ShortUrl/Entity/ShortUrl.php
+++ b/module/Core/src/ShortUrl/Entity/ShortUrl.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\Selectable;
 use Shlinkio\Shlink\Common\Entity\AbstractEntity;
 use Shlinkio\Shlink\Core\Domain\Entity\Domain;
 use Shlinkio\Shlink\Core\Exception\ShortCodeCannotBeRegeneratedException;
+use Shlinkio\Shlink\Core\RedirectRule\Entity\ShortUrlRedirectRule;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlCreation;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlEdition;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlMode;
@@ -39,6 +40,7 @@ class ShortUrl extends AbstractEntity
      * @param Collection<int, Tag> $tags
      * @param Collection<int, Visit> & Selectable<int, Visit> $visits
      * @param Collection<int, ShortUrlVisitsCount> & Selectable<int, ShortUrlVisitsCount> $visitsCounts
+     * @param Collection<int, ShortUrlRedirectRule> $redirectRules
      */
     private function __construct(
         private string $longUrl,
@@ -60,6 +62,7 @@ class ShortUrl extends AbstractEntity
         private bool $forwardQuery = true,
         private ?string $importSource = null,
         private ?string $importOriginalShortCode = null,
+        private Collection $redirectRules = new ArrayCollection(),
     ) {
     }
 
@@ -283,6 +286,7 @@ class ShortUrl extends AbstractEntity
                     Criteria::create()->where(Criteria::expr()->eq('potentialBot', false)),
                 )),
             ),
+            'hasRedirectRules' => count($this->redirectRules) > 0,
         ];
     }
 }

--- a/module/Core/src/ShortUrl/Entity/ShortUrl.php
+++ b/module/Core/src/ShortUrl/Entity/ShortUrl.php
@@ -264,7 +264,13 @@ class ShortUrl extends AbstractEntity
         return true;
     }
 
-    public function toArray(?VisitsSummary $precalculatedSummary = null): array
+    /**
+     * @param null|(callable(): string|null) $getAuthority -
+     *  This is a callback so that we trust its return value if provided, even if it is null.
+     *  Providing the raw authority as `string|null` would result in a fallback to `$this->domain` when the authority
+     *  was null.
+     */
+    public function toArray(?VisitsSummary $precalculatedSummary = null, callable|null $getAuthority = null): array
     {
         return [
             'shortCode' => $this->shortCode,
@@ -276,7 +282,7 @@ class ShortUrl extends AbstractEntity
                 'validUntil' => $this->validUntil?->toAtomString(),
                 'maxVisits' => $this->maxVisits,
             ],
-            'domain' => $this->domain,
+            'domain' => $getAuthority !== null ? $getAuthority() : $this->domain?->authority,
             'title' => $this->title,
             'crawlable' => $this->crawlable,
             'forwardQuery' => $this->forwardQuery,

--- a/module/Core/src/ShortUrl/Entity/ShortUrl.php
+++ b/module/Core/src/ShortUrl/Entity/ShortUrl.php
@@ -265,7 +265,7 @@ class ShortUrl extends AbstractEntity
     }
 
     /**
-     * @param null|(callable(): string|null) $getAuthority -
+     * @param null|(callable(): ?string) $getAuthority -
      *  This is a callback so that we trust its return value if provided, even if it is null.
      *  Providing the raw authority as `string|null` would result in a fallback to `$this->domain` when the authority
      *  was null.

--- a/module/Core/src/ShortUrl/Model/ShortUrlWithVisitsSummary.php
+++ b/module/Core/src/ShortUrl/Model/ShortUrlWithVisitsSummary.php
@@ -9,19 +9,26 @@ use Shlinkio\Shlink\Core\Visit\Model\VisitsSummary;
 
 final readonly class ShortUrlWithVisitsSummary
 {
-    private function __construct(public ShortUrl $shortUrl, private ?VisitsSummary $visitsSummary = null)
-    {
+    private function __construct(
+        public ShortUrl $shortUrl,
+        private VisitsSummary|null $visitsSummary = null,
+        private string|null $authority = null,
+    ) {
     }
 
     /**
-     * @param array{shortUrl: ShortUrl, visits: string|int, nonBotVisits: string|int} $data
+     * @param array{shortUrl: ShortUrl, visits: string|int, nonBotVisits: string|int, authority: string|null} $data
      */
     public static function fromArray(array $data): self
     {
-        return new self($data['shortUrl'], VisitsSummary::fromTotalAndNonBots(
-            (int) $data['visits'],
-            (int) $data['nonBotVisits'],
-        ));
+        return new self(
+            shortUrl: $data['shortUrl'],
+            visitsSummary: VisitsSummary::fromTotalAndNonBots(
+                total: (int) $data['visits'],
+                nonBots: (int) $data['nonBotVisits'],
+            ),
+            authority: $data['authority'] ?? null,
+        );
     }
 
     public static function fromShortUrl(ShortUrl $shortUrl): self
@@ -31,6 +38,6 @@ final readonly class ShortUrlWithVisitsSummary
 
     public function toArray(): array
     {
-        return $this->shortUrl->toArray($this->visitsSummary);
+        return $this->shortUrl->toArray($this->visitsSummary, fn() => $this->authority);
     }
 }

--- a/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
+++ b/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
@@ -56,7 +56,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
 
         $this->processOrderByForList($qb, $filtering);
 
-        /** @var array{shortUrl: ShortUrl, visits: string, nonBotVisits: string}[] $result */
+        /** @var array{shortUrl: ShortUrl, visits: string, nonBotVisits: string, authority: string|null}[] $result */
         $result = $qb->getQuery()->getResult();
         return map($result, static fn (array $s) => ShortUrlWithVisitsSummary::fromArray($s));
     }

--- a/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
+++ b/module/Core/src/ShortUrl/Repository/ShortUrlListRepository.php
@@ -43,7 +43,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
 
         $qb = $this->createListQueryBuilder($filtering);
         $qb->select(
-            'DISTINCT s AS shortUrl',
+            'DISTINCT s AS shortUrl, d.authority',
             '(' . $buildVisitsSubQuery('v', excludingBots: false) . ') AS ' . OrderableField::VISITS->value,
             '(' . $buildVisitsSubQuery('v2', excludingBots: true) . ') AS ' . OrderableField::NON_BOT_VISITS->value,
             // This is added only to have a consistent order by title between database engines
@@ -89,6 +89,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->from(ShortUrl::class, 's')
+           ->leftJoin('s.domain', 'd')
            ->where('1=1');
 
         $dateRange = $filtering->dateRange;
@@ -129,8 +130,7 @@ class ShortUrlListRepository extends EntitySpecificationRepository implements Sh
                 $conditions[] = $qb->expr()->like('t.name', ':searchPattern');
             }
 
-            $qb->leftJoin('s.domain', 'd')
-               ->andWhere($qb->expr()->orX(...$conditions))
+            $qb->andWhere($qb->expr()->orX(...$conditions))
                ->setParameter('searchPattern', '%' . $searchTerm . '%');
         }
 

--- a/module/Core/test/EventDispatcher/PublishingUpdatesGeneratorTest.php
+++ b/module/Core/test/EventDispatcher/PublishingUpdatesGeneratorTest.php
@@ -71,6 +71,7 @@ class PublishingUpdatesGeneratorTest extends TestCase
                 'crawlable' => false,
                 'forwardQuery' => true,
                 'visitsSummary' => VisitsSummary::fromTotalAndNonBots(0, 0),
+                'hasRedirectRules' => false,
             ],
             'visit' => [
                 'referer' => '',
@@ -145,6 +146,7 @@ class PublishingUpdatesGeneratorTest extends TestCase
             'crawlable' => false,
             'forwardQuery' => true,
             'visitsSummary' => VisitsSummary::fromTotalAndNonBots(0, 0),
+            'hasRedirectRules' => false,
         ]], $update->payload);
     }
 }

--- a/module/Rest/test-api/Action/ListShortUrlsTest.php
+++ b/module/Rest/test-api/Action/ListShortUrlsTest.php
@@ -34,6 +34,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => 'My cool title',
         'crawlable' => true,
         'forwardQuery' => true,
+        'hasRedirectRules' => false,
     ];
     private const SHORT_URL_DOCS = [
         'shortCode' => 'ghi789',
@@ -55,6 +56,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => null,
         'crawlable' => false,
         'forwardQuery' => true,
+        'hasRedirectRules' => false,
     ];
     private const SHORT_URL_CUSTOM_SLUG_AND_DOMAIN = [
         'shortCode' => 'custom-with-domain',
@@ -76,6 +78,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => null,
         'crawlable' => false,
         'forwardQuery' => true,
+        'hasRedirectRules' => false,
     ];
     private const SHORT_URL_META = [
         'shortCode' => 'def456',
@@ -99,6 +102,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => null,
         'crawlable' => false,
         'forwardQuery' => true,
+        'hasRedirectRules' => true,
     ];
     private const SHORT_URL_CUSTOM_SLUG = [
         'shortCode' => 'custom',
@@ -120,6 +124,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => null,
         'crawlable' => true,
         'forwardQuery' => false,
+        'hasRedirectRules' => false,
     ];
     private const SHORT_URL_CUSTOM_DOMAIN = [
         'shortCode' => 'ghi789',
@@ -143,6 +148,7 @@ class ListShortUrlsTest extends ApiTestCase
         'title' => null,
         'crawlable' => false,
         'forwardQuery' => true,
+        'hasRedirectRules' => false,
     ];
 
     #[Test, DataProvider('provideFilteredLists')]


### PR DESCRIPTION
Closes #2207 

Add a new `hasRedirectRules` field to the API's short URL model, which is a flag indicating if the short URL has any rules attached to it.

This new field causes an extra `SELECT COUNT` query per every short URL when listing, which is not perfect, but the result is fast enough and pagination mitigates the issue.

However, this PR fixes a similar issue with domains, ensuring the domain is fetched as part of the main list query and avoiding extra queries to resolve it for every entry on the list.