### PR TITLE
Update to shlink-common 6.5 to fix integration with redis 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.2.5] - 2024-11-03
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2244](https://github.com/shlinkio/shlink/issues/2244) Fix integration with Redis 7.4 and Valkey.
+
+
 ## [4.2.4] - 2024-10-27
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "pagerfanta/core": "^3.8",
         "ramsey/uuid": "^4.7",
         "shlinkio/doctrine-specification": "^2.1.1",
-        "shlinkio/shlink-common": "^6.4",
+        "shlinkio/shlink-common": "^6.5",
         "shlinkio/shlink-config": "^3.3",
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,13 +118,13 @@ services:
 
     shlink_redis:
         container_name: shlink_redis
-        image: redis:6.2-alpine
+        image: redis:7.4-alpine
         ports:
             - "6380:6379"
 
     shlink_redis_acl:
         container_name: shlink_redis_acl
-        image: redis:6.2-alpine
+        image: redis:7.4-alpine
         command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
         ports:
             - "6382:6379"


### PR DESCRIPTION
Fixes #2244 