### PR TITLE
Add new geolocatio-country-code redirect condition type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
     This change applies both to the `GET /short-urls` endpoint, via the `domain` query parameter, and the `short-url:list` console command, via the `--domain`|`-d` flag.
 
+* [#1774](https://github.com/shlinkio/shlink/issues/1774) Add new geolocation redirect rules for the dynamic redirects system.
+
+    * `geolocation-country-code`: Allows to perform redirections based on the ISO 3166-1 alpha-2 two-letter country code resolved while geolocating the visitor.
+
 ### Changed
 * [#2193](https://github.com/shlinkio/shlink/issues/2193) API keys are now hashed using SHA256, instead of being saved in plain text.
 

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",
         "shlinkio/shlink-installer": "^9.2",
-        "shlinkio/shlink-ip-geolocation": "^4.1",
+        "shlinkio/shlink-ip-geolocation": "dev-main#fadae5d as 4.2",
         "shlinkio/shlink-json": "^1.1",
         "spiral/roadrunner": "^2024.1",
         "spiral/roadrunner-cli": "^2.6",

--- a/docs/swagger/definitions/SetShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/SetShortUrlRedirectRule.json
@@ -15,7 +15,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["device", "language", "query-param", "ip-address"],
+            "enum": ["device", "language", "query-param", "ip-address", "geolocation-country-code"],
             "description": "The type of the condition, which will determine the logic used to match it"
           },
           "matchKey":  {

--- a/module/CLI/src/RedirectRule/RedirectRuleHandler.php
+++ b/module/CLI/src/RedirectRule/RedirectRuleHandler.php
@@ -111,6 +111,9 @@ class RedirectRuleHandler implements RedirectRuleHandlerInterface
                 RedirectConditionType::IP_ADDRESS => RedirectCondition::forIpAddress(
                     $this->askMandatory('IP address, CIDR block or wildcard-pattern (1.2.*.*)', $io),
                 ),
+                RedirectConditionType::GEOLOCATION_COUNTRY_CODE => RedirectCondition::forGeolocationCountryCode(
+                    $this->askMandatory('Country code to match?', $io),
+                )
             };
 
             $continue = $io->confirm('Do you want to add another condition?');

--- a/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
+++ b/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
@@ -117,6 +117,7 @@ class RedirectRuleHandlerTest extends TestCase
                 'Query param name?' => 'foo',
                 'Query param value?' => 'bar',
                 'IP address, CIDR block or wildcard-pattern (1.2.*.*)' => '1.2.3.4',
+                'Country code to match?' => 'FR',
                 default => '',
             },
         );
@@ -165,6 +166,10 @@ class RedirectRuleHandlerTest extends TestCase
             true,
         ];
         yield 'IP address' => [RedirectConditionType::IP_ADDRESS, [RedirectCondition::forIpAddress('1.2.3.4')]];
+        yield 'Geolocation country code' => [
+            RedirectConditionType::GEOLOCATION_COUNTRY_CODE,
+            [RedirectCondition::forGeolocationCountryCode('FR')],
+        ];
     }
 
     #[Test]

--- a/module/Core/src/Action/AbstractTrackingAction.php
+++ b/module/Core/src/Action/AbstractTrackingAction.php
@@ -15,6 +15,7 @@ use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\ShortUrl\ShortUrlResolverInterface;
 use Shlinkio\Shlink\Core\Visit\RequestTrackerInterface;
+use Shlinkio\Shlink\IpGeolocation\Model\Location;
 
 abstract class AbstractTrackingAction implements MiddlewareInterface, RequestMethodInterface
 {
@@ -30,9 +31,12 @@ abstract class AbstractTrackingAction implements MiddlewareInterface, RequestMet
 
         try {
             $shortUrl = $this->urlResolver->resolveEnabledShortUrl($identifier);
-            $this->requestTracker->trackIfApplicable($shortUrl, $request);
+            $visit = $this->requestTracker->trackIfApplicable($shortUrl, $request);
 
-            return $this->createSuccessResp($shortUrl, $request);
+            return $this->createSuccessResp(
+                $shortUrl,
+                $request->withAttribute(Location::class, $visit?->getVisitLocation()),
+            );
         } catch (ShortUrlNotFoundException) {
             return $this->createErrorResp($request, $handler);
         }

--- a/module/Core/src/Action/RedirectAction.php
+++ b/module/Core/src/Action/RedirectAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Core\Action;
 
-use Fig\Http\Message\StatusCodeInterface;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
@@ -13,7 +12,7 @@ use Shlinkio\Shlink\Core\ShortUrl\ShortUrlResolverInterface;
 use Shlinkio\Shlink\Core\Util\RedirectResponseHelperInterface;
 use Shlinkio\Shlink\Core\Visit\RequestTrackerInterface;
 
-class RedirectAction extends AbstractTrackingAction implements StatusCodeInterface
+class RedirectAction extends AbstractTrackingAction
 {
     public function __construct(
         ShortUrlResolverInterface $urlResolver,

--- a/module/Core/src/RedirectRule/Entity/RedirectCondition.php
+++ b/module/Core/src/RedirectRule/Entity/RedirectCondition.php
@@ -9,6 +9,7 @@ use Shlinkio\Shlink\Core\Model\DeviceType;
 use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
 use Shlinkio\Shlink\Core\RedirectRule\Model\Validation\RedirectRulesInputFilter;
 use Shlinkio\Shlink\Core\Util\IpAddressUtils;
+use Shlinkio\Shlink\Core\Visit\Entity\VisitLocation;
 use Shlinkio\Shlink\IpGeolocation\Model\Location;
 
 use function Shlinkio\Shlink\Core\acceptLanguageToLocales;
@@ -128,7 +129,8 @@ class RedirectCondition extends AbstractEntity implements JsonSerializable
     private function matchesGeolocationCountryCode(ServerRequestInterface $request): bool
     {
         $geolocation = $request->getAttribute(Location::class);
-        if (!($geolocation instanceof Location)) {
+        // TODO We should eventually rely on `Location` type only
+        if (! ($geolocation instanceof Location) && ! ($geolocation instanceof VisitLocation)) {
             return false;
         }
 

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -2,6 +2,12 @@
 
 namespace Shlinkio\Shlink\Core\RedirectRule\Model;
 
+use Shlinkio\Shlink\Core\Model\DeviceType;
+use Shlinkio\Shlink\Core\Util\IpAddressUtils;
+
+use function Shlinkio\Shlink\Core\ArrayUtils\contains;
+use function Shlinkio\Shlink\Core\enumValues;
+
 enum RedirectConditionType: string
 {
     case DEVICE = 'device';
@@ -9,4 +15,35 @@ enum RedirectConditionType: string
     case QUERY_PARAM = 'query-param';
     case IP_ADDRESS = 'ip-address';
     case GEOLOCATION_COUNTRY_CODE = 'geolocation-country-code';
+
+    /**
+     * Tells if a value is valid for the condition type
+     */
+    public function isValid(string $value): bool
+    {
+        return match ($this) {
+            RedirectConditionType::DEVICE => contains($value, enumValues(DeviceType::class)),
+            // RedirectConditionType::LANGUAGE => TODO Validate at least format,
+            RedirectConditionType::IP_ADDRESS => IpAddressUtils::isStaticIpCidrOrWildcard($value),
+            RedirectConditionType::GEOLOCATION_COUNTRY_CODE => contains($value, [
+                'AF', 'AX', 'AL', 'DZ', 'AS', 'AD', 'AO', 'AI', 'AQ', 'AG', 'AR', 'AM', 'AW', 'AU', 'AT', 'AZ',
+                'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BV', 'BR',
+                'IO', 'BN', 'BG', 'BF', 'BI', 'CV', 'KH', 'CM', 'CA', 'KY', 'CF', 'TD', 'CL', 'CN', 'CX', 'CC',
+                'CO', 'KM', 'CG', 'CD', 'CK', 'CR', 'CI', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO',
+                'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'SZ', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF',
+                'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GU', 'GT', 'GG', 'GN', 'GW', 'GY',
+                'HT', 'HM', 'VA', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IM', 'IL', 'IT', 'JM',
+                'JP', 'JE', 'JO', 'KZ', 'KE', 'KI', 'KP', 'KR', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY',
+                'LI', 'LT', 'LU', 'MO', 'MG', 'MW', 'MY', 'MV', 'ML', 'MT', 'MH', 'MQ', 'MR', 'MU', 'YT', 'MX',
+                'FM', 'MD', 'MC', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NP', 'NL', 'NC', 'NZ', 'NI',
+                'NE', 'NG', 'NU', 'NF', 'MK', 'MP', 'NO', 'OM', 'PK', 'PW', 'PS', 'PA', 'PG', 'PY', 'PE', 'PH',
+                'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'BL', 'SH', 'KN', 'LC', 'MF', 'PM', 'VC',
+                'WS', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SX', 'SK', 'SI', 'SB', 'SO', 'ZA', 'GS',
+                'SS', 'ES', 'LK', 'SD', 'SR', 'SJ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK',
+                'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'US', 'UM', 'UY', 'UZ', 'VU',
+                'VE', 'VN', 'VG', 'VI', 'WF', 'EH', 'YE', 'ZM', 'ZW',
+            ]),
+            default => true,
+        };
+    }
 }

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -26,6 +26,7 @@ enum RedirectConditionType: string
             // RedirectConditionType::LANGUAGE => TODO Validate at least format,
             RedirectConditionType::IP_ADDRESS => IpAddressUtils::isStaticIpCidrOrWildcard($value),
             RedirectConditionType::GEOLOCATION_COUNTRY_CODE => contains($value, [
+                // List of ISO 3166-1 alpha-2 two-letter country codes https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
                 'AF', 'AX', 'AL', 'DZ', 'AS', 'AD', 'AO', 'AI', 'AQ', 'AG', 'AR', 'AM', 'AW', 'AU', 'AT', 'AZ',
                 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BV', 'BR',
                 'IO', 'BN', 'BG', 'BF', 'BI', 'CV', 'KH', 'CM', 'CA', 'KY', 'CF', 'TD', 'CL', 'CN', 'CX', 'CC',

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -8,4 +8,5 @@ enum RedirectConditionType: string
     case LANGUAGE = 'language';
     case QUERY_PARAM = 'query-param';
     case IP_ADDRESS = 'ip-address';
+    case GEOLOCATION_COUNTRY_CODE = 'geolocation-country-code';
 }

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -97,8 +97,11 @@ class RedirectConditionTest extends TestCase
     }
 
     #[Test, DataProvider('provideVisits')]
-    public function matchesGeolocationCountryCode(Location|null $location, string $countryCodeToMatch, bool $expected): void
-    {
+    public function matchesGeolocationCountryCode(
+        Location|null $location,
+        string $countryCodeToMatch,
+        bool $expected,
+    ): void {
         $request = ServerRequestFactory::fromGlobals()->withAttribute(Location::class, $location);
         $result = RedirectCondition::forGeolocationCountryCode($countryCodeToMatch)->matchesRequest($request);
 

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Shlinkio\Shlink\Common\Middleware\IpAddressMiddlewareFactory;
 use Shlinkio\Shlink\Core\Model\DeviceType;
 use Shlinkio\Shlink\Core\RedirectRule\Entity\RedirectCondition;
+use Shlinkio\Shlink\Core\Visit\Entity\VisitLocation;
 use Shlinkio\Shlink\IpGeolocation\Model\Location;
 
 use const ShlinkioTest\Shlink\ANDROID_USER_AGENT;
@@ -98,7 +99,7 @@ class RedirectConditionTest extends TestCase
 
     #[Test, DataProvider('provideVisits')]
     public function matchesGeolocationCountryCode(
-        Location|null $location,
+        Location|VisitLocation|null $location,
         string $countryCodeToMatch,
         bool $expected,
     ): void {
@@ -113,5 +114,15 @@ class RedirectConditionTest extends TestCase
         yield 'non-matching location' => [new Location(countryCode: 'ES'), 'US', false];
         yield 'matching location' => [new Location(countryCode: 'US'), 'US', true];
         yield 'matching case-insensitive' => [new Location(countryCode: 'US'), 'us', true];
+        yield 'matching visit location' => [
+            VisitLocation::fromGeolocation(new Location(countryCode: 'US')),
+            'US',
+            true,
+        ];
+        yield 'matching visit case-insensitive' => [
+            VisitLocation::fromGeolocation(new Location(countryCode: 'es')),
+            'ES',
+            true,
+        ];
     }
 }

--- a/module/Core/test/RedirectRule/Model/RedirectRulesDataTest.php
+++ b/module/Core/test/RedirectRule/Model/RedirectRulesDataTest.php
@@ -63,6 +63,18 @@ class RedirectRulesDataTest extends TestCase
             ],
         ],
     ]]])]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'geolocation-country-code',
+                    'matchKey' => null,
+                    'matchValue' => 'not an country code',
+                ],
+            ],
+        ],
+    ]]])]
     public function throwsWhenProvidedDataIsInvalid(array $invalidData): void
     {
         $this->expectException(ValidationException::class);
@@ -118,6 +130,18 @@ class RedirectRulesDataTest extends TestCase
             ],
         ],
     ]]], 'in-between IP wildcard pattern')]
+    #[TestWith([['redirectRules' => [
+        [
+            'longUrl' => 'https://example.com',
+            'conditions' => [
+                [
+                    'type' => 'geolocation-country-code',
+                    'matchKey' => null,
+                    'matchValue' => 'US',
+                ],
+            ],
+        ],
+    ]]], 'country code')]
     public function allowsValidDataToBeSet(array $validData): void
     {
         $result = RedirectRulesData::fromRawData($validData);

--- a/module/Core/test/ShortUrl/Middleware/ExtraPathRedirectMiddlewareTest.php
+++ b/module/Core/test/ShortUrl/Middleware/ExtraPathRedirectMiddlewareTest.php
@@ -9,6 +9,7 @@ use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\Uri;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -26,6 +27,7 @@ use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\ShortUrl\ShortUrlResolverInterface;
 use Shlinkio\Shlink\Core\Util\RedirectResponseHelperInterface;
 use Shlinkio\Shlink\Core\Visit\RequestTrackerInterface;
+use Shlinkio\Shlink\IpGeolocation\Model\Location;
 
 use function Laminas\Stratigility\middleware;
 use function str_starts_with;
@@ -153,7 +155,10 @@ class ExtraPathRedirectMiddlewareTest extends TestCase
         );
         $this->redirectionBuilder->expects($this->once())->method('buildShortUrlRedirect')->with(
             $shortUrl,
-            $this->isInstanceOf(ServerRequestInterface::class),
+            $this->callback(function (ServerRequestInterface $req) {
+                Assert::assertArrayHasKey(Location::class, $req->getAttributes());
+                return true;
+            }),
             $expectedExtraPath,
         )->willReturn('the_built_long_url');
         $this->redirectResponseHelper->expects($this->once())->method('buildRedirectResponse')->with(

--- a/module/Rest/test-api/Action/SetRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/SetRedirectRulesTest.php
@@ -96,6 +96,20 @@ class SetRedirectRulesTest extends ApiTestCase
             ],
         ],
     ]], 'invalid IP address')]
+    #[TestWith([[
+        'redirectRules' => [
+            [
+                'longUrl' => 'https://example.com',
+                'conditions' => [
+                    [
+                        'type' => 'geolocation-country-code',
+                        'matchKey' => null,
+                        'matchValue' => 'not a country code',
+                    ],
+                ],
+            ],
+        ],
+    ]], 'invalid country code')]
     public function errorIsReturnedWhenInvalidDataIsProvided(array $bodyPayload): void
     {
         $response = $this->callApiWithKey(self::METHOD_POST, '/short-urls/abc123/redirect-rules', [


### PR DESCRIPTION
Part of #1774 

Add a new type of condition for the dynamic rule-based redirection system.

This condition checks if the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code resulting of geolocating current visitor matches configured country code.

This condition will never match if geolocation is not configured, or it is disabled, and there's always a chance of a visitor to be incorrectly geolocated, so there's a small chance of false negatives/positives.

During condition creation, only the country code will be validated, but Shlink won't warn you if geolocation is not configured/enabled at that point.