### PR TITLE
Add support for city name dynamic redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * [#1774](https://github.com/shlinkio/shlink/issues/1774) Add new geolocation redirect rules for the dynamic redirects system.
 
     * `geolocation-country-code`: Allows to perform redirections based on the ISO 3166-1 alpha-2 two-letter country code resolved while geolocating the visitor.
+    * `geolocation-city-name`: Allows to perform redirections based on the city name resolved while geolocating the visitor.
 
 ### Changed
 * [#2193](https://github.com/shlinkio/shlink/issues/2193) API keys are now hashed using SHA256, instead of being saved in plain text.

--- a/docs/swagger/definitions/SetShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/SetShortUrlRedirectRule.json
@@ -15,7 +15,14 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["device", "language", "query-param", "ip-address", "geolocation-country-code"],
+            "enum": [
+              "device",
+              "language",
+              "query-param",
+              "ip-address",
+              "geolocation-country-code",
+              "geolocation-city-name"
+            ],
             "description": "The type of the condition, which will determine the logic used to match it"
           },
           "matchKey":  {

--- a/module/CLI/src/RedirectRule/RedirectRuleHandler.php
+++ b/module/CLI/src/RedirectRule/RedirectRuleHandler.php
@@ -113,6 +113,9 @@ class RedirectRuleHandler implements RedirectRuleHandlerInterface
                 ),
                 RedirectConditionType::GEOLOCATION_COUNTRY_CODE => RedirectCondition::forGeolocationCountryCode(
                     $this->askMandatory('Country code to match?', $io),
+                ),
+                RedirectConditionType::GEOLOCATION_CITY_NAME => RedirectCondition::forGeolocationCityName(
+                    $this->askMandatory('City name to match?', $io),
                 )
             };
 

--- a/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
+++ b/module/CLI/test/RedirectRule/RedirectRuleHandlerTest.php
@@ -118,6 +118,7 @@ class RedirectRuleHandlerTest extends TestCase
                 'Query param value?' => 'bar',
                 'IP address, CIDR block or wildcard-pattern (1.2.*.*)' => '1.2.3.4',
                 'Country code to match?' => 'FR',
+                'City name to match?' => 'Los angeles',
                 default => '',
             },
         );
@@ -169,6 +170,10 @@ class RedirectRuleHandlerTest extends TestCase
         yield 'Geolocation country code' => [
             RedirectConditionType::GEOLOCATION_COUNTRY_CODE,
             [RedirectCondition::forGeolocationCountryCode('FR')],
+        ];
+        yield 'Geolocation city name' => [
+            RedirectConditionType::GEOLOCATION_CITY_NAME,
+            [RedirectCondition::forGeolocationCityName('Los angeles')],
         ];
     }
 

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -15,6 +15,7 @@ enum RedirectConditionType: string
     case QUERY_PARAM = 'query-param';
     case IP_ADDRESS = 'ip-address';
     case GEOLOCATION_COUNTRY_CODE = 'geolocation-country-code';
+    case GEOLOCATION_CITY_NAME = 'geolocation-city-name';
 
     /**
      * Tells if a value is valid for the condition type

--- a/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
+++ b/module/Core/test/RedirectRule/Entity/RedirectConditionTest.php
@@ -97,7 +97,7 @@ class RedirectConditionTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    #[Test, DataProvider('provideVisits')]
+    #[Test, DataProvider('provideVisitsWithCountry')]
     public function matchesGeolocationCountryCode(
         Location|VisitLocation|null $location,
         string $countryCodeToMatch,
@@ -108,7 +108,7 @@ class RedirectConditionTest extends TestCase
 
         self::assertEquals($expected, $result);
     }
-    public static function provideVisits(): iterable
+    public static function provideVisitsWithCountry(): iterable
     {
         yield 'no location' => [null, 'US', false];
         yield 'non-matching location' => [new Location(countryCode: 'ES'), 'US', false];
@@ -122,6 +122,35 @@ class RedirectConditionTest extends TestCase
         yield 'matching visit case-insensitive' => [
             VisitLocation::fromGeolocation(new Location(countryCode: 'es')),
             'ES',
+            true,
+        ];
+    }
+
+    #[Test, DataProvider('provideVisitsWithCity')]
+    public function matchesGeolocationCityName(
+        Location|VisitLocation|null $location,
+        string $cityNameToMatch,
+        bool $expected,
+    ): void {
+        $request = ServerRequestFactory::fromGlobals()->withAttribute(Location::class, $location);
+        $result = RedirectCondition::forGeolocationCityName($cityNameToMatch)->matchesRequest($request);
+
+        self::assertEquals($expected, $result);
+    }
+    public static function provideVisitsWithCity(): iterable
+    {
+        yield 'no location' => [null, 'New York', false];
+        yield 'non-matching location' => [new Location(city: 'Los Angeles'), 'New York', false];
+        yield 'matching location' => [new Location(city: 'Madrid'), 'Madrid', true];
+        yield 'matching case-insensitive' => [new Location(city: 'Los Angeles'), 'los angeles', true];
+        yield 'matching visit location' => [
+            VisitLocation::fromGeolocation(new Location(city: 'New York')),
+            'New York',
+            true,
+        ];
+        yield 'matching visit case-insensitive' => [
+            VisitLocation::fromGeolocation(new Location(city: 'barcelona')),
+            'Barcelona',
             true,
         ];
     }


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink/issues/1774

Add a new type of condition for the dynamic rule-based redirection system.

This condition checks if the city name resulting of geolocating current visitor matches configured one.

This condition will never match if geolocation is not configured, or it is disabled, and there's always a chance of a visitor to be incorrectly geolocated, so there's a small chance of false negatives/positives.

The city name is also not validated, so human errors or typos would also result in incorrect matchings.

Additionally, Shlink won't warn you if geolocation is not configured/enabled when a condition of this type is created.