### PR TITLE
Do not allow pipelines to continue on error

### DIFF
--- a/.github/workflows/ci-db-tests.yml
+++ b/.github/workflows/ci-db-tests.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
-    continue-on-error: ${{ matrix.php-version == '8.4' }}
     env:
       LC_ALL: C
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
-    continue-on-error: ${{ matrix.php-version == '8.4' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # rr get-binary picks this env automatically
     steps:


### PR DESCRIPTION
The project has been properly working with PHP 8.4 for a while, so let's remove `continue-on-error: ${{ matrix.php-version == '8.4' }}` from all workflows.