### PR TITLE
Use more meaningful domain exceptions to represent ApiKeyService thrown errors

### DIFF
--- a/module/Rest/src/Exception/ApiKeyConflictException.php
+++ b/module/Rest/src/Exception/ApiKeyConflictException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Rest\Exception;
+
+use function sprintf;
+
+class ApiKeyConflictException extends RuntimeException implements ExceptionInterface
+{
+    public static function forName(string $name): self
+    {
+        return new self(sprintf('An API key with name "%s" already exists', $name));
+    }
+}

--- a/module/Rest/src/Exception/ApiKeyNotFoundException.php
+++ b/module/Rest/src/Exception/ApiKeyNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Rest\Exception;
+
+use function sprintf;
+
+class ApiKeyNotFoundException extends RuntimeException implements ExceptionInterface
+{
+    public static function forName(string $name): self
+    {
+        return new self(sprintf('API key with name "%s" not found', $name));
+    }
+
+    /** @deprecated */
+    public static function forKey(string $key): self
+    {
+        return new self(sprintf('API key with key "%s" not found', $key));
+    }
+}

--- a/module/Rest/src/Service/ApiKeyServiceInterface.php
+++ b/module/Rest/src/Service/ApiKeyServiceInterface.php
@@ -8,6 +8,8 @@ use Shlinkio\Shlink\Common\Exception\InvalidArgumentException;
 use Shlinkio\Shlink\Core\Model\Renaming;
 use Shlinkio\Shlink\Rest\ApiKey\Model\ApiKeyMeta;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
+use Shlinkio\Shlink\Rest\Exception\ApiKeyConflictException;
+use Shlinkio\Shlink\Rest\Exception\ApiKeyNotFoundException;
 
 interface ApiKeyServiceInterface
 {
@@ -21,13 +23,13 @@ interface ApiKeyServiceInterface
     public function check(string $key): ApiKeyCheckResult;
 
     /**
-     * @throws InvalidArgumentException
+     * @throws ApiKeyNotFoundException
      */
     public function disableByName(string $apiKeyName): ApiKey;
 
     /**
      * @deprecated Use `self::disableByName($name)` instead
-     * @throws InvalidArgumentException
+     * @throws ApiKeyNotFoundException
      */
     public function disableByKey(string $key): ApiKey;
 
@@ -37,7 +39,8 @@ interface ApiKeyServiceInterface
     public function listKeys(bool $enabledOnly = false): array;
 
     /**
-     * @throws InvalidArgumentException If an API key with oldName does not exist, or newName is in use by another one
+     * @throws ApiKeyNotFoundException
+     * @throws ApiKeyConflictException
      */
     public function renameApiKey(Renaming $apiKeyRenaming): ApiKey;
 }

--- a/module/Rest/test/Service/ApiKeyServiceTest.php
+++ b/module/Rest/test/Service/ApiKeyServiceTest.php
@@ -17,6 +17,8 @@ use Shlinkio\Shlink\Rest\ApiKey\Model\ApiKeyMeta;
 use Shlinkio\Shlink\Rest\ApiKey\Model\RoleDefinition;
 use Shlinkio\Shlink\Rest\ApiKey\Repository\ApiKeyRepositoryInterface;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
+use Shlinkio\Shlink\Rest\Exception\ApiKeyConflictException;
+use Shlinkio\Shlink\Rest\Exception\ApiKeyNotFoundException;
 use Shlinkio\Shlink\Rest\Service\ApiKeyService;
 
 use function substr;
@@ -145,7 +147,7 @@ class ApiKeyServiceTest extends TestCase
     {
         $this->repo->expects($this->once())->method('findOneBy')->with($findOneByArg)->willReturn(null);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ApiKeyNotFoundException::class);
 
         $this->service->{$disableMethod}('12345');
     }
@@ -217,8 +219,8 @@ class ApiKeyServiceTest extends TestCase
         $this->repo->expects($this->once())->method('findOneBy')->with(['name' => 'old'])->willReturn(null);
         $this->repo->expects($this->never())->method('nameExists');
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('API key with name "old" could not be found');
+        $this->expectException(ApiKeyNotFoundException::class);
+        $this->expectExceptionMessage('API key with name "old" not found');
 
         $this->service->renameApiKey($renaming);
     }
@@ -246,8 +248,8 @@ class ApiKeyServiceTest extends TestCase
         $this->repo->expects($this->once())->method('findOneBy')->with(['name' => 'old'])->willReturn($apiKey);
         $this->repo->expects($this->once())->method('nameExists')->with('new')->willReturn(true);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Another API key with name "new" already exists');
+        $this->expectException(ApiKeyConflictException::class);
+        $this->expectExceptionMessage('An API key with name "new" already exists');
 
         $this->service->renameApiKey($renaming);
     }


### PR DESCRIPTION
Instead of reusing the same generic exception for all errors thrown by `ApiKeyService`, use more meaningful and specific domain exceptions.