### PR TITLE
Make sure IpGeolocationMiddleware skips localhost

### DIFF
--- a/module/Core/src/Geolocation/Middleware/IpGeolocationMiddleware.php
+++ b/module/Core/src/Geolocation/Middleware/IpGeolocationMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
+use Shlinkio\Shlink\Common\Util\IpAddress;
 use Shlinkio\Shlink\Core\Config\Options\TrackingOptions;
 use Shlinkio\Shlink\IpGeolocation\Exception\WrongIpException;
 use Shlinkio\Shlink\IpGeolocation\GeoLite2\DbUpdaterInterface;
@@ -46,7 +47,9 @@ readonly class IpGeolocationMiddleware implements MiddlewareInterface
     private function geolocateIpAddress(string|null $ipAddress): Location
     {
         try {
-            return $ipAddress === null ? Location::empty() : $this->ipLocationResolver->resolveIpLocation($ipAddress);
+            return $ipAddress === null || $ipAddress === IpAddress::LOCALHOST
+                ? Location::empty()
+                : $this->ipLocationResolver->resolveIpLocation($ipAddress);
         } catch (WrongIpException $e) {
             $this->logger->warning('Tried to locate IP address, but it seems to be wrong. {e}', ['e' => $e]);
             return Location::empty();

--- a/module/Core/src/Visit/Entity/Visit.php
+++ b/module/Core/src/Visit/Entity/Visit.php
@@ -127,11 +127,6 @@ class Visit extends AbstractEntity implements JsonSerializable
         return $this->visitLocation;
     }
 
-    public function isLocatable(): bool
-    {
-        return $this->hasRemoteAddr() && $this->remoteAddr !== IpAddress::LOCALHOST;
-    }
-
     public function locate(VisitLocation $visitLocation): self
     {
         $this->visitLocation = $visitLocation;

--- a/module/Core/src/Visit/Geolocation/VisitLocator.php
+++ b/module/Core/src/Visit/Geolocation/VisitLocator.php
@@ -54,7 +54,7 @@ readonly class VisitLocator implements VisitLocatorInterface
                 }
 
                 // If the IP address is non-locatable, locate it as empty to prevent next processes to pick it again
-                $location = Location::emptyInstance();
+                $location = Location::empty();
             }
 
             $this->locateVisit($visit, VisitLocation::fromGeolocation($location), $helper);


### PR DESCRIPTION
This PR brings back some logic that was lost while migrating geolocation logic from `LocateVisit` event to `IpGeolocationMiddleware` https://github.com/shlinkio/shlink/pull/2266, to make sure localhost addresses resolve to an empty location rather than trying to geolocate them.