### PR TITLE
Add visited short URL info to every visit

### DIFF
--- a/module/Core/config/dependencies.config.php
+++ b/module/Core/config/dependencies.config.php
@@ -10,7 +10,6 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Shlinkio\Shlink\Common\Doctrine\EntityRepositoryFactory;
 use Shlinkio\Shlink\Core\Config\Options\NotFoundRedirectOptions;
 use Shlinkio\Shlink\Core\Geolocation\GeolocationDbUpdater;
-use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifier;
 use Shlinkio\Shlink\Importer\ImportedLinksProcessorInterface;
 use Shlinkio\Shlink\IpGeolocation\GeoLite2\DbUpdater;
 use Shlinkio\Shlink\IpGeolocation\GeoLite2\GeoLite2ReaderFactory;
@@ -94,6 +93,7 @@ return [
             ],
             Visit\Listener\ShortUrlVisitsCountTracker::class => InvokableFactory::class,
             Visit\Listener\OrphanVisitsCountTracker::class => InvokableFactory::class,
+            Visit\Transformer\VisitDataTransformer::class => ConfigAbstractFactory::class,
 
             Util\DoctrineBatchHelper::class => ConfigAbstractFactory::class,
             Util\RedirectResponseHelper::class => ConfigAbstractFactory::class,
@@ -128,7 +128,7 @@ return [
         Matomo\MatomoTrackerBuilder::class => [Matomo\MatomoOptions::class],
         Matomo\MatomoVisitSender::class => [
             Matomo\MatomoTrackerBuilder::class,
-            ShortUrlStringifier::class,
+            ShortUrl\Helper\ShortUrlStringifier::class,
             Visit\Repository\VisitIterationRepository::class,
         ],
 
@@ -168,6 +168,7 @@ return [
         Visit\Geolocation\VisitLocator::class => ['em', Visit\Repository\VisitIterationRepository::class],
         Visit\Geolocation\VisitToLocationHelper::class => [IpLocationResolverInterface::class],
         Visit\VisitsStatsHelper::class => ['em'],
+        Visit\Transformer\VisitDataTransformer::class => [ShortUrl\Helper\ShortUrlStringifier::class],
         Tag\TagService::class => ['em', Tag\Repository\TagRepository::class],
         ShortUrl\DeleteShortUrlService::class => [
             'em',

--- a/module/Core/src/Visit/Entity/Visit.php
+++ b/module/Core/src/Visit/Entity/Visit.php
@@ -169,16 +169,24 @@ class Visit extends AbstractEntity implements JsonSerializable
             'visitedUrl' => $this->visitedUrl,
             'redirectUrl' => $this->redirectUrl,
         ];
-        if ($this->shortUrl !== null) {
-            return $visitedShortUrlToArray === null ? $base : [
+
+        // Orphan visit
+        if ($this->shortUrl === null) {
+            return [
                 ...$base,
-                'visitedShortUrl' => $visitedShortUrlToArray($this->shortUrl),
+                'type' => $this->type->value,
             ];
+
+        }
+
+        // Should not include visited short URL
+        if ($visitedShortUrlToArray === null) {
+            return $base;
         }
 
         return [
             ...$base,
-            'type' => $this->type->value,
+            'visitedShortUrl' => $visitedShortUrlToArray($this->shortUrl),
         ];
     }
 }

--- a/module/Core/src/Visit/Entity/Visit.php
+++ b/module/Core/src/Visit/Entity/Visit.php
@@ -151,6 +151,15 @@ class Visit extends AbstractEntity implements JsonSerializable
 
     public function jsonSerialize(): array
     {
+        return $this->toArray();
+    }
+
+    /**
+     * @phpstan-type VisitedShortUrl array{shortCode: string, domain: string|null, shortUrl: string}
+     * @param (callable(ShortUrl $shortUrl): VisitedShortUrl)|null $visitedShortUrlToArray
+     */
+    public function toArray(callable|null $visitedShortUrlToArray = null): array
+    {
         $base = [
             'referer' => $this->referer,
             'date' => $this->date->toAtomString(),
@@ -160,8 +169,11 @@ class Visit extends AbstractEntity implements JsonSerializable
             'visitedUrl' => $this->visitedUrl,
             'redirectUrl' => $this->redirectUrl,
         ];
-        if (! $this->isOrphan()) {
-            return $base;
+        if ($this->shortUrl !== null) {
+            return $visitedShortUrlToArray === null ? $base : [
+                ...$base,
+                'visitedShortUrl' => $visitedShortUrlToArray($this->shortUrl),
+            ];
         }
 
         return [

--- a/module/Core/src/Visit/Transformer/VisitDataTransformer.php
+++ b/module/Core/src/Visit/Transformer/VisitDataTransformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Visit\Transformer;
+
+use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
+use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifierInterface;
+use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+
+readonly class VisitDataTransformer implements VisitDataTransformerInterface
+{
+    public function __construct(private ShortUrlStringifierInterface $stringifier)
+    {
+    }
+
+    public function transform(Visit $visit): array
+    {
+        return $visit->toArray(fn (ShortUrl $shortUrl) => [
+            'shortCode' => $shortUrl->getShortCode(),
+            'domain' => $shortUrl->getDomain()?->authority,
+            'shortUrl' => $this->stringifier->stringify($shortUrl),
+        ]);
+    }
+}

--- a/module/Core/src/Visit/Transformer/VisitDataTransformerInterface.php
+++ b/module/Core/src/Visit/Transformer/VisitDataTransformerInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Core\Visit\Transformer;
+
+use Shlinkio\Shlink\Core\Visit\Entity\Visit;
+
+interface VisitDataTransformerInterface
+{
+    public function transform(Visit $visit): array;
+}

--- a/module/Rest/config/dependencies.config.php
+++ b/module/Rest/config/dependencies.config.php
@@ -85,16 +85,29 @@ return [
             ShortUrl\ShortUrlResolver::class,
             ShortUrlDataTransformer::class,
         ],
-        Action\Visit\ShortUrlVisitsAction::class => [Visit\VisitsStatsHelper::class],
-        Action\Visit\TagVisitsAction::class => [Visit\VisitsStatsHelper::class],
+        Action\Visit\ShortUrlVisitsAction::class => [
+            Visit\VisitsStatsHelper::class,
+            Visit\Transformer\VisitDataTransformer::class,
+        ],
+        Action\Visit\TagVisitsAction::class => [
+            Visit\VisitsStatsHelper::class,
+            Visit\Transformer\VisitDataTransformer::class,
+        ],
         Action\Visit\DomainVisitsAction::class => [
             Visit\VisitsStatsHelper::class,
             Config\Options\UrlShortenerOptions::class,
+            Visit\Transformer\VisitDataTransformer::class,
         ],
         Action\Visit\GlobalVisitsAction::class => [Visit\VisitsStatsHelper::class],
-        Action\Visit\OrphanVisitsAction::class => [Visit\VisitsStatsHelper::class],
+        Action\Visit\OrphanVisitsAction::class => [
+            Visit\VisitsStatsHelper::class,
+            Visit\Transformer\VisitDataTransformer::class,
+        ],
         Action\Visit\DeleteOrphanVisitsAction::class => [Visit\VisitsDeleter::class],
-        Action\Visit\NonOrphanVisitsAction::class => [Visit\VisitsStatsHelper::class],
+        Action\Visit\NonOrphanVisitsAction::class => [
+            Visit\VisitsStatsHelper::class,
+            Visit\Transformer\VisitDataTransformer::class,
+        ],
         Action\ShortUrl\ListShortUrlsAction::class => [
             ShortUrl\ShortUrlListService::class,
             ShortUrlDataTransformer::class,

--- a/module/Rest/src/Action/Visit/DomainVisitsAction.php
+++ b/module/Rest/src/Action/Visit/DomainVisitsAction.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 use Shlinkio\Shlink\Core\Config\Options\UrlShortenerOptions;
 use Shlinkio\Shlink\Core\Domain\Entity\Domain;
 use Shlinkio\Shlink\Core\Visit\Model\VisitsParams;
+use Shlinkio\Shlink\Core\Visit\Transformer\VisitDataTransformerInterface;
 use Shlinkio\Shlink\Core\Visit\VisitsStatsHelperInterface;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
@@ -19,8 +20,9 @@ class DomainVisitsAction extends AbstractListVisitsAction
     public function __construct(
         VisitsStatsHelperInterface $visitsHelper,
         private readonly UrlShortenerOptions $urlShortenerOptions,
+        VisitDataTransformerInterface $transformer,
     ) {
-        parent::__construct($visitsHelper);
+        parent::__construct($visitsHelper, $transformer);
     }
 
     protected function getVisitsPaginator(Request $request, VisitsParams $params, ApiKey $apiKey): Pagerfanta


### PR DESCRIPTION
Part of #2180 

In order to be able to relate every visit with the short URL that created it, this PR adds a new `visitedShortUrl` prop to every visit when serialized, which is an object with this type: `array{shortCode: string, domain: string|null, shortUrl: string}`