### PR TITLE
Go back to using akrabat/ip-address-middleware instead of acelaya/ip-address-middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-mbstring": "*",
         "ext-pdo": "*",
         "acelaya/crawler-detect": "^1.3",
-        "acelaya/ip-address-middleware": "^2.4",
+        "akrabat/ip-address-middleware": "^2.4",
         "cakephp/chronos": "^3.1",
         "doctrine/dbal": "^4.2",
         "doctrine/migrations": "^3.8",


### PR DESCRIPTION
The package `akrabat/ip-address-middleware` has published a new version which addresses the PHP 8.4 warnings, so we can go back to use it instead of `acelaya/ip-address-middleware`