### PR TITLE
Fix columns order in unique_short_code_plus_domain index in MSSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+# [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2285](https://github.com/shlinkio/shlink/issues/2285) Fix performance degradation when using Microsoft SQL due to incorrect order of columns in `unique_short_code_plus_domain` index.
+
+
 ## [4.3.0] - 2024-11-24
 ### Added
 * [#2159](https://github.com/shlinkio/shlink/issues/2159) Add support for PHP 8.4.

--- a/module/Core/migrations/Version20241125213106.php
+++ b/module/Core/migrations/Version20241125213106.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkMigrations;
+
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241125213106 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(! $this->isMsSql());
+
+        // Recreate unique_short_code_plus_domain index in Microsoft SQL, as it accidentally has the columns defined in
+        // the wrong order after Version20230130090946 migration
+        $shortUrls = $schema->getTable('short_urls');
+        $shortUrls->dropIndex('unique_short_code_plus_domain');
+        $shortUrls->addUniqueIndex(['short_code', 'domain_id'], 'unique_short_code_plus_domain');
+    }
+
+    private function isMsSql(): bool
+    {
+        return $this->connection->getDatabasePlatform() instanceof SQLServerPlatform;
+    }
+}


### PR DESCRIPTION
Close #2285 

Fix the columns order in `unique_short_code_plus_domain` index in Microsoft SQL.

The columns were in the wrong order due to [Version20230130090946.php](https://github.com/shlinkio/shlink/blob/eff4f1fca357aa3ffc85d07ec30c7124d0c99f63/module/Core/migrations/Version20230130090946.php#L30-L32)