### PR TITLE
Allow the extra path to be ignored when redirecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 # [Unreleased]
 ### Added
-* *Nothing*
+* [#2265](https://github.com/shlinkio/shlink/issues/2265) Add a new `REDIRECT_EXTRA_PATH_MODE` option that accepts three values:
+
+    * `default`: Short URLs only match if the path matches their short code or custom slug.
+    * `append`: Short URLs are matched as soon as the path starts with the short code or custom slug, and the extra path is appended to the long URL before redirecting.
+    * `ignore`: Short URLs are matched as soon as the path starts with the short code or custom slug, and the extra path is ignored.
+
+    This option effectively replaces the old `REDIRECT_APPEND_EXTRA_PATH` option, which is now deprecated and will be removed in Shlink 5.0.0
 
 ### Changed
 * * [#2281](https://github.com/shlinkio/shlink/issues/2281) Update docker image to PHP 8.4

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "shlinkio/shlink-config": "^3.4",
         "shlinkio/shlink-event-dispatcher": "^4.1",
         "shlinkio/shlink-importer": "^5.3.2",
-        "shlinkio/shlink-installer": "^9.3",
+        "shlinkio/shlink-installer": "dev-develop#957db97 as 9.4",
         "shlinkio/shlink-ip-geolocation": "^4.2",
         "shlinkio/shlink-json": "^1.1",
         "spiral/roadrunner": "^2024.1",

--- a/composer.json
+++ b/composer.json
@@ -154,8 +154,8 @@
             "@test:cli",
             "phpcov merge build/coverage-cli --html build/coverage-cli/coverage-html && rm build/coverage-cli/*.cov"
         ],
-        "swagger:validate": "php-openapi validate docs/swagger/swagger.json",
-        "swagger:inline": "php-openapi inline docs/swagger/swagger.json docs/swagger/swagger-inlined.json",
+        "swagger:validate": "@php -d error_reporting=\"E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED\" vendor/bin/php-openapi validate docs/swagger/swagger.json",
+        "swagger:inline": "@php -d error_reporting=\"E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED\" vendor/bin/php-openapi inline docs/swagger/swagger.json docs/swagger/swagger-inlined.json",
         "clean:dev": "rm -f data/database.sqlite && rm -f config/params/generated_config.php"
     },
     "scripts-descriptions": {

--- a/config/autoload/installer.global.php
+++ b/config/autoload/installer.global.php
@@ -41,7 +41,7 @@ return [
             Option\UrlShortener\RedirectStatusCodeConfigOption::class,
             Option\UrlShortener\RedirectCacheLifeTimeConfigOption::class,
             Option\UrlShortener\AutoResolveTitlesConfigOption::class,
-            Option\UrlShortener\AppendExtraPathConfigOption::class,
+            Option\UrlShortener\ExtraPathModeConfigOption::class,
             Option\UrlShortener\EnableMultiSegmentSlugsConfigOption::class,
             Option\UrlShortener\EnableTrailingSlashConfigOption::class,
             Option\UrlShortener\ShortUrlModeConfigOption::class,

--- a/module/Core/src/Config/EnvVars.php
+++ b/module/Core/src/Config/EnvVars.php
@@ -84,7 +84,7 @@ enum EnvVars: string
     case IS_HTTPS_ENABLED = 'IS_HTTPS_ENABLED';
     case DEFAULT_DOMAIN = 'DEFAULT_DOMAIN';
     case AUTO_RESOLVE_TITLES = 'AUTO_RESOLVE_TITLES';
-    case REDIRECT_APPEND_EXTRA_PATH = 'REDIRECT_APPEND_EXTRA_PATH';
+    case REDIRECT_EXTRA_PATH_MODE = 'REDIRECT_EXTRA_PATH_MODE';
     case MULTI_SEGMENT_SLUGS_ENABLED = 'MULTI_SEGMENT_SLUGS_ENABLED';
     case ROBOTS_ALLOW_ALL_SHORT_URLS = 'ROBOTS_ALLOW_ALL_SHORT_URLS';
     case ROBOTS_USER_AGENTS = 'ROBOTS_USER_AGENTS';
@@ -92,6 +92,8 @@ enum EnvVars: string
     case MEMORY_LIMIT = 'MEMORY_LIMIT';
     case INITIAL_API_KEY = 'INITIAL_API_KEY';
     case SKIP_INITIAL_GEOLITE_DOWNLOAD = 'SKIP_INITIAL_GEOLITE_DOWNLOAD';
+    /** @deprecated Use REDIRECT_EXTRA_PATH */
+    case REDIRECT_APPEND_EXTRA_PATH = 'REDIRECT_APPEND_EXTRA_PATH';
 
     public function loadFromEnv(): mixed
     {
@@ -125,11 +127,13 @@ enum EnvVars: string
             self::DEFAULT_SHORT_CODES_LENGTH => DEFAULT_SHORT_CODES_LENGTH,
             self::SHORT_URL_MODE => ShortUrlMode::STRICT->value,
             self::IS_HTTPS_ENABLED, self::AUTO_RESOLVE_TITLES => true,
-            self::REDIRECT_APPEND_EXTRA_PATH,
             self::MULTI_SEGMENT_SLUGS_ENABLED,
             self::SHORT_URL_TRAILING_SLASH => false,
             self::DEFAULT_DOMAIN, self::BASE_PATH => '',
             self::CACHE_NAMESPACE => 'Shlink',
+            // Deprecated. In Shlink 5.0.0, add default value for REDIRECT_EXTRA_PATH_MODE
+            self::REDIRECT_APPEND_EXTRA_PATH => false,
+            // self::REDIRECT_EXTRA_PATH_MODE => ExtraPathMode::DEFAULT->value,
 
             self::REDIS_PUB_SUB_ENABLED,
             self::MATOMO_ENABLED,

--- a/module/Core/src/Config/Options/ExtraPathMode.php
+++ b/module/Core/src/Config/Options/ExtraPathMode.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Shlinkio\Shlink\Core\Config\Options;
+
+enum ExtraPathMode: string
+{
+    /** URLs with extra path will not match a short URL */
+    case DEFAULT = 'default';
+    /** The extra path will be appended to the long URL */
+    case APPEND = 'append';
+    /** The extra path will be ignored */
+    case IGNORE = 'ignore';
+}

--- a/module/Core/src/ShortUrl/Middleware/ExtraPathRedirectMiddleware.php
+++ b/module/Core/src/ShortUrl/Middleware/ExtraPathRedirectMiddleware.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Shlinkio\Shlink\Core\Config\Options\ExtraPathMode;
 use Shlinkio\Shlink\Core\Config\Options\UrlShortenerOptions;
 use Shlinkio\Shlink\Core\ErrorHandler\Model\NotFoundType;
 use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
@@ -51,7 +52,7 @@ readonly class ExtraPathRedirectMiddleware implements MiddlewareInterface
 
     private function shouldApplyLogic(NotFoundType|null $notFoundType): bool
     {
-        if ($notFoundType === null || ! $this->urlShortenerOptions->appendExtraPath) {
+        if ($notFoundType === null || $this->urlShortenerOptions->extraPathMode === ExtraPathMode::DEFAULT) {
             return false;
         }
 
@@ -75,7 +76,11 @@ readonly class ExtraPathRedirectMiddleware implements MiddlewareInterface
 
         try {
             $shortUrl = $this->resolver->resolveEnabledShortUrl($identifier);
-            $longUrl = $this->redirectionBuilder->buildShortUrlRedirect($shortUrl, $request, $extraPath);
+            $longUrl = $this->redirectionBuilder->buildShortUrlRedirect(
+                $shortUrl,
+                $request,
+                $this->urlShortenerOptions->extraPathMode === ExtraPathMode::APPEND ? $extraPath : null,
+            );
             $this->requestTracker->trackIfApplicable(
                 $shortUrl,
                 $request->withAttribute(REDIRECT_URL_REQUEST_ATTRIBUTE, $longUrl),


### PR DESCRIPTION
Closes #2265 

Add a new `REDIRECT_EXTRA_PATH_MODE` option to have more granularity when it comes to matching short URLs with extra path.

Up until now it was possible to set `REDIRECT_APPEND_EXTRA_PATH` with values true or false. When true, short URLs would only match if the visited path was exactly the short code or custom slug of a URL. When false, they would match as long as they **started** with the short code or custom slug, and the rest of the path would be appended to the long URL before redirecting.

The new option replaces this one by providing extra path modes:

* `default`: Same as setting `REDIRECT_APPEND_EXTRA_PATH` to false.
* `append`:  Same as setting `REDIRECT_APPEND_EXTRA_PATH` to true.
* `ignore`: Will match short URLs using the same logic as `append`, but the extra path will be discarded instead.

With this PR `REDIRECT_APPEND_EXTRA_PATH` becomes deprecated and marked for removal in Shlink 5.0.0