### PR TITLE
Drop support for PHP 8.2

### DIFF
--- a/.github/workflows/ci-db-tests.yml
+++ b/.github/workflows/ci-db-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
     env:
       LC_ALL: C
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # rr get-binary picks this env automatically
     steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
       - uses: './.github/actions/ci-setup'

--- a/.github/workflows/publish-swagger-spec.yml
+++ b/.github/workflows/publish-swagger-spec.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.2']
+        php-version: ['8.3']
     steps:
       - uses: actions/checkout@v4
       - name: Determine version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Removed
-* *Nothing*
+* * [#2247](https://github.com/shlinkio/shlink/issues/2247) Drop support for PHP 8.2
 
 ### Fixed
 * *Nothing*

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The idea is that you can just generate a container using the image and provide t
 
 First, make sure the host where you are going to run shlink fulfills these requirements:
 
-* PHP 8.2 or 8.3
+* PHP 8.3 or 8.4
 * The next PHP extensions: json, curl, pdo, intl, gd and gmp/bcmath.
     * apcu extension is recommended if you don't plan to use RoadRunner.
     * xml extension is required if you want to generate QR codes in svg format.

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-curl": "*",
         "ext-gd": "*",
         "ext-json": "*",

--- a/module/CLI/src/Command/Api/DisableKeyCommand.php
+++ b/module/CLI/src/Command/Api/DisableKeyCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
 
 class DisableKeyCommand extends Command
 {
-    public const NAME = 'api-key:disable';
+    public const string NAME = 'api-key:disable';
 
     public function __construct(private readonly ApiKeyServiceInterface $apiKeyService)
     {

--- a/module/CLI/src/Command/Api/GenerateKeyCommand.php
+++ b/module/CLI/src/Command/Api/GenerateKeyCommand.php
@@ -23,7 +23,7 @@ use function sprintf;
 
 class GenerateKeyCommand extends Command
 {
-    public const NAME = 'api-key:generate';
+    public const string NAME = 'api-key:generate';
 
     public function __construct(
         private readonly ApiKeyServiceInterface $apiKeyService,

--- a/module/CLI/src/Command/Api/InitialApiKeyCommand.php
+++ b/module/CLI/src/Command/Api/InitialApiKeyCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class InitialApiKeyCommand extends Command
 {
-    public const NAME = 'api-key:initial';
+    public const string NAME = 'api-key:initial';
 
     public function __construct(private readonly ApiKeyServiceInterface $apiKeyService)
     {

--- a/module/CLI/src/Command/Api/ListKeysCommand.php
+++ b/module/CLI/src/Command/Api/ListKeysCommand.php
@@ -21,11 +21,11 @@ use function sprintf;
 
 class ListKeysCommand extends Command
 {
-    private const ERROR_STRING_PATTERN = '<fg=red>%s</>';
-    private const SUCCESS_STRING_PATTERN = '<info>%s</info>';
-    private const WARNING_STRING_PATTERN = '<comment>%s</comment>';
+    private const string ERROR_STRING_PATTERN = '<fg=red>%s</>';
+    private const string SUCCESS_STRING_PATTERN = '<info>%s</info>';
+    private const string WARNING_STRING_PATTERN = '<comment>%s</comment>';
 
-    public const NAME = 'api-key:list';
+    public const string NAME = 'api-key:list';
 
     public function __construct(private readonly ApiKeyServiceInterface $apiKeyService)
     {

--- a/module/CLI/src/Command/Api/RenameApiKeyCommand.php
+++ b/module/CLI/src/Command/Api/RenameApiKeyCommand.php
@@ -19,7 +19,7 @@ use function Shlinkio\Shlink\Core\ArrayUtils\map;
 
 class RenameApiKeyCommand extends Command
 {
-    public const NAME = 'api-key:rename';
+    public const string NAME = 'api-key:rename';
 
     public function __construct(private readonly ApiKeyServiceInterface $apiKeyService)
     {

--- a/module/CLI/src/Command/Config/ReadEnvVarCommand.php
+++ b/module/CLI/src/Command/Config/ReadEnvVarCommand.php
@@ -21,7 +21,7 @@ use function sprintf;
 
 class ReadEnvVarCommand extends Command
 {
-    public const NAME = 'env-var:read';
+    public const string NAME = 'env-var:read';
 
     /** @var Closure(string $envVar): mixed */
     private readonly Closure $loadEnvVar;

--- a/module/CLI/src/Command/Db/CreateDatabaseCommand.php
+++ b/module/CLI/src/Command/Db/CreateDatabaseCommand.php
@@ -24,9 +24,9 @@ class CreateDatabaseCommand extends AbstractDatabaseCommand
 {
     private readonly Connection $regularConn;
 
-    public const NAME = 'db:create';
-    public const DOCTRINE_SCRIPT = 'bin/doctrine';
-    public const DOCTRINE_CREATE_SCHEMA_COMMAND = 'orm:schema-tool:create';
+    public const string NAME = 'db:create';
+    public const string DOCTRINE_SCRIPT = 'bin/doctrine';
+    public const string DOCTRINE_CREATE_SCHEMA_COMMAND = 'orm:schema-tool:create';
 
     public function __construct(
         LockFactory $locker,

--- a/module/CLI/src/Command/Db/MigrateDatabaseCommand.php
+++ b/module/CLI/src/Command/Db/MigrateDatabaseCommand.php
@@ -11,9 +11,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class MigrateDatabaseCommand extends AbstractDatabaseCommand
 {
-    public const NAME = 'db:migrate';
-    public const DOCTRINE_MIGRATIONS_SCRIPT = 'vendor/doctrine/migrations/bin/doctrine-migrations.php';
-    public const DOCTRINE_MIGRATE_COMMAND = 'migrations:migrate';
+    public const string NAME = 'db:migrate';
+    public const string DOCTRINE_MIGRATIONS_SCRIPT = 'vendor/doctrine/migrations/bin/doctrine-migrations.php';
+    public const string DOCTRINE_MIGRATE_COMMAND = 'migrations:migrate';
 
     protected function configure(): void
     {

--- a/module/CLI/src/Command/Domain/DomainRedirectsCommand.php
+++ b/module/CLI/src/Command/Domain/DomainRedirectsCommand.php
@@ -21,7 +21,7 @@ use function str_contains;
 
 class DomainRedirectsCommand extends Command
 {
-    public const NAME = 'domain:redirects';
+    public const string NAME = 'domain:redirects';
 
     public function __construct(private readonly DomainServiceInterface $domainService)
     {

--- a/module/CLI/src/Command/Domain/GetDomainVisitsCommand.php
+++ b/module/CLI/src/Command/Domain/GetDomainVisitsCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class GetDomainVisitsCommand extends AbstractVisitsListCommand
 {
-    public const NAME = 'domain:visits';
+    public const string NAME = 'domain:visits';
 
     public function __construct(
         VisitsStatsHelperInterface $visitsHelper,

--- a/module/CLI/src/Command/Domain/ListDomainsCommand.php
+++ b/module/CLI/src/Command/Domain/ListDomainsCommand.php
@@ -18,7 +18,7 @@ use function array_map;
 
 class ListDomainsCommand extends Command
 {
-    public const NAME = 'domain:list';
+    public const string NAME = 'domain:list';
 
     public function __construct(private readonly DomainServiceInterface $domainService)
     {

--- a/module/CLI/src/Command/Integration/MatomoSendVisitsCommand.php
+++ b/module/CLI/src/Command/Integration/MatomoSendVisitsCommand.php
@@ -22,7 +22,7 @@ use function sprintf;
 
 class MatomoSendVisitsCommand extends Command implements VisitSendingProgressTrackerInterface
 {
-    public const NAME = 'integration:matomo:send-visits';
+    public const string NAME = 'integration:matomo:send-visits';
 
     private readonly bool $matomoEnabled;
     private SymfonyStyle $io;

--- a/module/CLI/src/Command/RedirectRule/ManageRedirectRulesCommand.php
+++ b/module/CLI/src/Command/RedirectRule/ManageRedirectRulesCommand.php
@@ -19,7 +19,7 @@ use function sprintf;
 
 class ManageRedirectRulesCommand extends Command
 {
-    public const NAME = 'short-url:manage-rules';
+    public const string NAME = 'short-url:manage-rules';
 
     private readonly ShortUrlIdentifierInput $shortUrlIdentifierInput;
 

--- a/module/CLI/src/Command/ShortUrl/CreateShortUrlCommand.php
+++ b/module/CLI/src/Command/ShortUrl/CreateShortUrlCommand.php
@@ -20,7 +20,7 @@ use function sprintf;
 
 class CreateShortUrlCommand extends Command
 {
-    public const NAME = 'short-url:create';
+    public const string NAME = 'short-url:create';
 
     private SymfonyStyle $io;
     private readonly ShortUrlDataInput $shortUrlDataInput;

--- a/module/CLI/src/Command/ShortUrl/DeleteExpiredShortUrlsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/DeleteExpiredShortUrlsCommand.php
@@ -17,7 +17,7 @@ use function sprintf;
 
 class DeleteExpiredShortUrlsCommand extends Command
 {
-    public const NAME = 'short-url:delete-expired';
+    public const string NAME = 'short-url:delete-expired';
 
     public function __construct(private readonly DeleteShortUrlServiceInterface $deleteShortUrlService)
     {

--- a/module/CLI/src/Command/ShortUrl/DeleteShortUrlCommand.php
+++ b/module/CLI/src/Command/ShortUrl/DeleteShortUrlCommand.php
@@ -19,7 +19,7 @@ use function sprintf;
 
 class DeleteShortUrlCommand extends Command
 {
-    public const NAME = 'short-url:delete';
+    public const string NAME = 'short-url:delete';
 
     private readonly ShortUrlIdentifierInput $shortUrlIdentifierInput;
 

--- a/module/CLI/src/Command/ShortUrl/DeleteShortUrlVisitsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/DeleteShortUrlVisitsCommand.php
@@ -16,7 +16,7 @@ use function sprintf;
 
 class DeleteShortUrlVisitsCommand extends AbstractDeleteVisitsCommand
 {
-    public const NAME = 'short-url:visits-delete';
+    public const string NAME = 'short-url:visits-delete';
 
     private readonly ShortUrlIdentifierInput $shortUrlIdentifierInput;
 

--- a/module/CLI/src/Command/ShortUrl/EditShortUrlCommand.php
+++ b/module/CLI/src/Command/ShortUrl/EditShortUrlCommand.php
@@ -19,7 +19,7 @@ use function sprintf;
 
 class EditShortUrlCommand extends Command
 {
-    public const NAME = 'short-url:edit';
+    public const string NAME = 'short-url:edit';
 
     private readonly ShortUrlDataInput $shortUrlDataInput;
     private readonly ShortUrlIdentifierInput $shortUrlIdentifierInput;

--- a/module/CLI/src/Command/ShortUrl/GetShortUrlVisitsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/GetShortUrlVisitsCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class GetShortUrlVisitsCommand extends AbstractVisitsListCommand
 {
-    public const NAME = 'short-url:visits';
+    public const string NAME = 'short-url:visits';
 
     private ShortUrlIdentifierInput $shortUrlIdentifierInput;
 

--- a/module/CLI/src/Command/ShortUrl/ListShortUrlsCommand.php
+++ b/module/CLI/src/Command/ShortUrl/ListShortUrlsCommand.php
@@ -33,7 +33,7 @@ use function sprintf;
 
 class ListShortUrlsCommand extends Command
 {
-    public const NAME = 'short-url:list';
+    public const string NAME = 'short-url:list';
 
     private readonly StartDateOption $startDateOption;
     private readonly EndDateOption $endDateOption;

--- a/module/CLI/src/Command/ShortUrl/ResolveUrlCommand.php
+++ b/module/CLI/src/Command/ShortUrl/ResolveUrlCommand.php
@@ -17,7 +17,7 @@ use function sprintf;
 
 class ResolveUrlCommand extends Command
 {
-    public const NAME = 'short-url:parse';
+    public const string NAME = 'short-url:parse';
 
     private readonly ShortUrlIdentifierInput $shortUrlIdentifierInput;
 

--- a/module/CLI/src/Command/Tag/DeleteTagsCommand.php
+++ b/module/CLI/src/Command/Tag/DeleteTagsCommand.php
@@ -14,9 +14,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class DeleteTagsCommand extends Command
 {
-    public const NAME = 'tag:delete';
+    public const string NAME = 'tag:delete';
 
-    public function __construct(private TagServiceInterface $tagService)
+    public function __construct(private readonly TagServiceInterface $tagService)
     {
         parent::__construct();
     }

--- a/module/CLI/src/Command/Tag/GetTagVisitsCommand.php
+++ b/module/CLI/src/Command/Tag/GetTagVisitsCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class GetTagVisitsCommand extends AbstractVisitsListCommand
 {
-    public const NAME = 'tag:visits';
+    public const string NAME = 'tag:visits';
 
     public function __construct(
         VisitsStatsHelperInterface $visitsHelper,

--- a/module/CLI/src/Command/Tag/ListTagsCommand.php
+++ b/module/CLI/src/Command/Tag/ListTagsCommand.php
@@ -17,7 +17,7 @@ use function array_map;
 
 class ListTagsCommand extends Command
 {
-    public const NAME = 'tag:list';
+    public const string NAME = 'tag:list';
 
     public function __construct(private readonly TagServiceInterface $tagService)
     {

--- a/module/CLI/src/Command/Tag/RenameTagCommand.php
+++ b/module/CLI/src/Command/Tag/RenameTagCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class RenameTagCommand extends Command
 {
-    public const NAME = 'tag:rename';
+    public const string NAME = 'tag:rename';
 
     public function __construct(private readonly TagServiceInterface $tagService)
     {

--- a/module/CLI/src/Command/Util/LockedCommandConfig.php
+++ b/module/CLI/src/Command/Util/LockedCommandConfig.php
@@ -6,7 +6,7 @@ namespace Shlinkio\Shlink\CLI\Command\Util;
 
 final class LockedCommandConfig
 {
-    public const DEFAULT_TTL = 600.0; // 10 minutes
+    public const float DEFAULT_TTL = 600.0; // 10 minutes
 
     private function __construct(
         public readonly string $lockName,

--- a/module/CLI/src/Command/Visit/DeleteOrphanVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/DeleteOrphanVisitsCommand.php
@@ -13,7 +13,7 @@ use function sprintf;
 
 class DeleteOrphanVisitsCommand extends AbstractDeleteVisitsCommand
 {
-    public const NAME = 'visit:orphan-delete';
+    public const string NAME = 'visit:orphan-delete';
 
     public function __construct(private readonly VisitsDeleterInterface $deleter)
     {

--- a/module/CLI/src/Command/Visit/DownloadGeoLiteDbCommand.php
+++ b/module/CLI/src/Command/Visit/DownloadGeoLiteDbCommand.php
@@ -18,7 +18,7 @@ use function sprintf;
 
 class DownloadGeoLiteDbCommand extends Command
 {
-    public const NAME = 'visit:download-db';
+    public const string NAME = 'visit:download-db';
 
     private ProgressBar|null $progressBar = null;
 

--- a/module/CLI/src/Command/Visit/GetNonOrphanVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/GetNonOrphanVisitsCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 
 class GetNonOrphanVisitsCommand extends AbstractVisitsListCommand
 {
-    public const NAME = 'visit:non-orphan';
+    public const string NAME = 'visit:non-orphan';
 
     public function __construct(
         VisitsStatsHelperInterface $visitsHelper,

--- a/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/GetOrphanVisitsCommand.php
@@ -17,7 +17,7 @@ use function sprintf;
 
 class GetOrphanVisitsCommand extends AbstractVisitsListCommand
 {
-    public const NAME = 'visit:orphan';
+    public const string NAME = 'visit:orphan';
 
     protected function configure(): void
     {

--- a/module/CLI/src/Command/Visit/LocateVisitsCommand.php
+++ b/module/CLI/src/Command/Visit/LocateVisitsCommand.php
@@ -29,7 +29,7 @@ use function sprintf;
 
 class LocateVisitsCommand extends AbstractLockedCommand implements VisitGeolocationHelperInterface
 {
-    public const NAME = 'visit:locate';
+    public const string NAME = 'visit:locate';
 
     private SymfonyStyle $io;
 

--- a/module/CLI/src/GeoLite/GeolocationDbUpdater.php
+++ b/module/CLI/src/GeoLite/GeolocationDbUpdater.php
@@ -20,7 +20,7 @@ use function is_int;
 
 class GeolocationDbUpdater implements GeolocationDbUpdaterInterface
 {
-    private const LOCK_NAME = 'geolocation-db-update';
+    private const string LOCK_NAME = 'geolocation-db-update';
 
     /** @var Closure(): Reader */
     private readonly Closure $geoLiteDbReaderFactory;

--- a/module/CLI/src/Util/ExitCode.php
+++ b/module/CLI/src/Util/ExitCode.php
@@ -6,7 +6,7 @@ namespace Shlinkio\Shlink\CLI\Util;
 
 final class ExitCode
 {
-    public const EXIT_SUCCESS = 0;
-    public const EXIT_FAILURE = -1;
-    public const EXIT_WARNING = 1;
+    public const int EXIT_SUCCESS = 0;
+    public const int EXIT_FAILURE = -1;
+    public const int EXIT_WARNING = 1;
 }

--- a/module/CLI/src/Util/ShlinkTable.php
+++ b/module/CLI/src/Util/ShlinkTable.php
@@ -12,8 +12,8 @@ use function array_pop;
 
 final class ShlinkTable
 {
-    private const DEFAULT_STYLE_NAME = 'default';
-    private const TABLE_TITLE_STYLE = '<options=bold> %s </>';
+    private const string DEFAULT_STYLE_NAME = 'default';
+    private const string TABLE_TITLE_STYLE = '<options=bold> %s </>';
 
     private function __construct(private readonly Table $baseTable, private readonly bool $withRowSeparators = false)
     {

--- a/module/Core/migrations/Version20230211171904.php
+++ b/module/Core/migrations/Version20230211171904.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20230211171904 extends AbstractMigration
 {
-    private const INDEX_NAME = 'IDX_visits_potential_bot';
+    private const string INDEX_NAME = 'IDX_visits_potential_bot';
 
     public function up(Schema $schema): void
     {

--- a/module/Core/migrations/Version20230303164233.php
+++ b/module/Core/migrations/Version20230303164233.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20230303164233 extends AbstractMigration
 {
-    private const INDEX_NAME = 'visits_potential_bot_IDX';
+    private const string INDEX_NAME = 'visits_potential_bot_IDX';
 
     public function up(Schema $schema): void
     {

--- a/module/Core/migrations/Version20240220214031.php
+++ b/module/Core/migrations/Version20240220214031.php
@@ -17,8 +17,12 @@ use function in_array;
  */
 final class Version20240220214031 extends AbstractMigration
 {
-    private const DOMAINS_COLUMNS = ['base_url_redirect', 'regular_not_found_redirect', 'invalid_short_url_redirect'];
-    private const TEXT_COLUMNS = [
+    private const array DOMAINS_COLUMNS = [
+        'base_url_redirect',
+        'regular_not_found_redirect',
+        'invalid_short_url_redirect',
+    ];
+    private const array TEXT_COLUMNS = [
         'domains' => self::DOMAINS_COLUMNS,
         'short_urls' => ['original_url'],
     ];

--- a/module/Core/migrations/Version20241124112257.php
+++ b/module/Core/migrations/Version20241124112257.php
@@ -11,7 +11,7 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20241124112257 extends AbstractMigration
 {
-    private const COLUMN_NAME = 'redirect_url';
+    private const string COLUMN_NAME = 'redirect_url';
 
     public function up(Schema $schema): void
     {

--- a/module/Core/src/Action/Model/QrCodeParams.php
+++ b/module/Core/src/Action/Model/QrCodeParams.php
@@ -30,9 +30,9 @@ use const Shlinkio\Shlink\DEFAULT_QR_CODE_COLOR;
 
 final class QrCodeParams
 {
-    private const MIN_SIZE = 50;
-    private const MAX_SIZE = 1000;
-    private const SUPPORTED_FORMATS = ['png', 'svg'];
+    private const int MIN_SIZE = 50;
+    private const int MAX_SIZE = 1000;
+    private const array SUPPORTED_FORMATS = ['png', 'svg'];
 
     private function __construct(
         public readonly int $size,

--- a/module/Core/src/Config/NotFoundRedirectResolver.php
+++ b/module/Core/src/Config/NotFoundRedirectResolver.php
@@ -17,8 +17,8 @@ use function urlencode;
 
 class NotFoundRedirectResolver implements NotFoundRedirectResolverInterface
 {
-    private const DOMAIN_PLACEHOLDER = '{DOMAIN}';
-    private const ORIGINAL_PATH_PLACEHOLDER = '{ORIGINAL_PATH}';
+    private const string DOMAIN_PLACEHOLDER = '{DOMAIN}';
+    private const string ORIGINAL_PATH_PLACEHOLDER = '{ORIGINAL_PATH}';
 
     public function __construct(
         private readonly RedirectResponseHelperInterface $redirectResponseHelper,

--- a/module/Core/src/Config/PostProcessor/BasePathPrefixer.php
+++ b/module/Core/src/Config/PostProcessor/BasePathPrefixer.php
@@ -8,7 +8,7 @@ use function array_map;
 
 class BasePathPrefixer
 {
-    private const ELEMENTS_WITH_PATH = ['routes', 'middleware_pipeline'];
+    private const array ELEMENTS_WITH_PATH = ['routes', 'middleware_pipeline'];
 
     public function __invoke(array $config): array
     {

--- a/module/Core/src/Config/PostProcessor/MultiSegmentSlugProcessor.php
+++ b/module/Core/src/Config/PostProcessor/MultiSegmentSlugProcessor.php
@@ -11,8 +11,8 @@ use function str_replace;
 
 class MultiSegmentSlugProcessor
 {
-    private const SINGLE_SEGMENT_PATTERN = '{shortCode}';
-    private const MULTI_SEGMENT_PATTERN = '{shortCode:.+}';
+    private const string SINGLE_SEGMENT_PATTERN = '{shortCode}';
+    private const string MULTI_SEGMENT_PATTERN = '{shortCode:.+}';
 
     public function __invoke(array $config): array
     {

--- a/module/Core/src/Domain/Entity/Domain.php
+++ b/module/Core/src/Domain/Entity/Domain.php
@@ -11,7 +11,7 @@ use Shlinkio\Shlink\Core\Config\NotFoundRedirects;
 
 class Domain extends AbstractEntity implements JsonSerializable, NotFoundRedirectConfigInterface
 {
-    public const DEFAULT_AUTHORITY = 'DEFAULT';
+    public const string DEFAULT_AUTHORITY = 'DEFAULT';
 
     private function __construct(
         public readonly string $authority,

--- a/module/Core/src/Domain/Validation/DomainRedirectsInputFilter.php
+++ b/module/Core/src/Domain/Validation/DomainRedirectsInputFilter.php
@@ -11,10 +11,10 @@ use Shlinkio\Shlink\Common\Validation\InputFactory;
 /** @extends InputFilter<mixed> */
 class DomainRedirectsInputFilter extends InputFilter
 {
-    public const DOMAIN = 'domain';
-    public const BASE_URL_REDIRECT = 'baseUrlRedirect';
-    public const REGULAR_404_REDIRECT = 'regular404Redirect';
-    public const INVALID_SHORT_URL_REDIRECT = 'invalidShortUrlRedirect';
+    public const string DOMAIN = 'domain';
+    public const string BASE_URL_REDIRECT = 'baseUrlRedirect';
+    public const string REGULAR_404_REDIRECT = 'regular404Redirect';
+    public const string INVALID_SHORT_URL_REDIRECT = 'invalidShortUrlRedirect';
 
     private function __construct()
     {

--- a/module/Core/src/ErrorHandler/NotFoundTemplateHandler.php
+++ b/module/Core/src/ErrorHandler/NotFoundTemplateHandler.php
@@ -17,9 +17,9 @@ use function sprintf;
 
 class NotFoundTemplateHandler implements RequestHandlerInterface
 {
-    private const TEMPLATES_BASE_DIR = __DIR__ . '/../../templates';
-    public const NOT_FOUND_TEMPLATE = '404.html';
-    public const INVALID_SHORT_CODE_TEMPLATE = 'invalid-short-code.html';
+    private const string TEMPLATES_BASE_DIR = __DIR__ . '/../../templates';
+    public const string NOT_FOUND_TEMPLATE = '404.html';
+    public const string INVALID_SHORT_CODE_TEMPLATE = 'invalid-short-code.html';
 
     private Closure $readFile;
 

--- a/module/Core/src/Exception/DeleteShortUrlException.php
+++ b/module/Core/src/Exception/DeleteShortUrlException.php
@@ -16,8 +16,8 @@ class DeleteShortUrlException extends DomainException implements ProblemDetailsE
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Cannot delete short URL';
-    public const ERROR_CODE = 'invalid-short-url-deletion';
+    private const string TITLE = 'Cannot delete short URL';
+    public const string ERROR_CODE = 'invalid-short-url-deletion';
 
     public static function fromVisitsThreshold(int $threshold, ShortUrlIdentifier $identifier): self
     {

--- a/module/Core/src/Exception/DomainNotFoundException.php
+++ b/module/Core/src/Exception/DomainNotFoundException.php
@@ -15,8 +15,8 @@ class DomainNotFoundException extends DomainException implements ProblemDetailsE
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Domain not found';
-    public const ERROR_CODE = 'domain-not-found';
+    private const string TITLE = 'Domain not found';
+    public const string ERROR_CODE = 'domain-not-found';
 
     private function __construct(string $message, array $additional)
     {

--- a/module/Core/src/Exception/ForbiddenTagOperationException.php
+++ b/module/Core/src/Exception/ForbiddenTagOperationException.php
@@ -14,8 +14,8 @@ class ForbiddenTagOperationException extends DomainException implements ProblemD
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Forbidden tag operation';
-    public const ERROR_CODE = 'forbidden-tag-operation';
+    private const string TITLE = 'Forbidden tag operation';
+    public const string ERROR_CODE = 'forbidden-tag-operation';
 
     public static function forDeletion(): self
     {

--- a/module/Core/src/Exception/NonUniqueSlugException.php
+++ b/module/Core/src/Exception/NonUniqueSlugException.php
@@ -16,8 +16,8 @@ class NonUniqueSlugException extends InvalidArgumentException implements Problem
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Invalid custom slug';
-    public const ERROR_CODE = 'non-unique-slug';
+    private const string TITLE = 'Invalid custom slug';
+    public const string ERROR_CODE = 'non-unique-slug';
 
     public static function fromSlug(string $slug, string|null $domain = null): self
     {

--- a/module/Core/src/Exception/ShortUrlNotFoundException.php
+++ b/module/Core/src/Exception/ShortUrlNotFoundException.php
@@ -16,8 +16,8 @@ class ShortUrlNotFoundException extends DomainException implements ProblemDetail
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Short URL not found';
-    public const ERROR_CODE = 'short-url-not-found';
+    private const string TITLE = 'Short URL not found';
+    public const string ERROR_CODE = 'short-url-not-found';
 
     public static function fromNotFound(ShortUrlIdentifier $identifier): self
     {

--- a/module/Core/src/Exception/TagConflictException.php
+++ b/module/Core/src/Exception/TagConflictException.php
@@ -16,8 +16,8 @@ class TagConflictException extends RuntimeException implements ProblemDetailsExc
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Tag conflict';
-    public const ERROR_CODE = 'tag-conflict';
+    private const string TITLE = 'Tag conflict';
+    public const string ERROR_CODE = 'tag-conflict';
 
     public static function forExistingTag(Renaming $renaming): self
     {

--- a/module/Core/src/Exception/TagNotFoundException.php
+++ b/module/Core/src/Exception/TagNotFoundException.php
@@ -15,8 +15,8 @@ class TagNotFoundException extends DomainException implements ProblemDetailsExce
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Tag not found';
-    public const ERROR_CODE = 'tag-not-found';
+    private const string TITLE = 'Tag not found';
+    public const string ERROR_CODE = 'tag-not-found';
 
     public static function fromTag(string $tag): self
     {

--- a/module/Core/src/Exception/ValidationException.php
+++ b/module/Core/src/Exception/ValidationException.php
@@ -21,8 +21,8 @@ class ValidationException extends InvalidArgumentException implements ProblemDet
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Invalid data';
-    public const ERROR_CODE = 'invalid-data';
+    private const string TITLE = 'Invalid data';
+    public const string ERROR_CODE = 'invalid-data';
 
     private array $invalidElements;
 

--- a/module/Core/src/Matomo/MatomoTrackerBuilder.php
+++ b/module/Core/src/Matomo/MatomoTrackerBuilder.php
@@ -9,7 +9,7 @@ use Shlinkio\Shlink\Core\Exception\RuntimeException;
 
 readonly class MatomoTrackerBuilder implements MatomoTrackerBuilderInterface
 {
-    public const MATOMO_DEFAULT_TIMEOUT = 10; // Time in seconds
+    public const int MATOMO_DEFAULT_TIMEOUT = 10; // Time in seconds
 
     public function __construct(private MatomoOptions $options)
     {

--- a/module/Core/src/Model/Ordering.php
+++ b/module/Core/src/Model/Ordering.php
@@ -6,9 +6,9 @@ namespace Shlinkio\Shlink\Core\Model;
 
 final readonly class Ordering
 {
-    private const DESC_DIR = 'DESC';
-    private const ASC_DIR = 'ASC';
-    private const DEFAULT_DIR = self::ASC_DIR;
+    private const string DESC_DIR = 'DESC';
+    private const string ASC_DIR = 'ASC';
+    private const string DEFAULT_DIR = self::ASC_DIR;
 
     public function __construct(public string|null $field = null, public string $direction = self::DEFAULT_DIR)
     {

--- a/module/Core/src/RedirectRule/Model/Validation/RedirectRulesInputFilter.php
+++ b/module/Core/src/RedirectRule/Model/Validation/RedirectRulesInputFilter.php
@@ -17,14 +17,14 @@ use function Shlinkio\Shlink\Core\enumValues;
 /** @extends InputFilter<mixed> */
 class RedirectRulesInputFilter extends InputFilter
 {
-    public const REDIRECT_RULES = 'redirectRules';
+    public const string REDIRECT_RULES = 'redirectRules';
 
-    public const RULE_LONG_URL = 'longUrl';
-    public const RULE_CONDITIONS = 'conditions';
+    public const string RULE_LONG_URL = 'longUrl';
+    public const string RULE_CONDITIONS = 'conditions';
 
-    public const CONDITION_TYPE = 'type';
-    public const CONDITION_MATCH_VALUE = 'matchValue';
-    public const CONDITION_MATCH_KEY = 'matchKey';
+    public const string CONDITION_TYPE = 'type';
+    public const string CONDITION_MATCH_VALUE = 'matchValue';
+    public const string CONDITION_MATCH_KEY = 'matchKey';
 
     private function __construct()
     {

--- a/module/Core/src/ShortUrl/Helper/ShortUrlTitleResolutionHelper.php
+++ b/module/Core/src/ShortUrl/Helper/ShortUrlTitleResolutionHelper.php
@@ -21,14 +21,14 @@ use function trim;
 
 readonly class ShortUrlTitleResolutionHelper implements ShortUrlTitleResolutionHelperInterface
 {
-    public const MAX_REDIRECTS = 15;
-    public const CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
+    public const int MAX_REDIRECTS = 15;
+    public const string CHROME_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
         . 'Chrome/121.0.0.0 Safari/537.36';
 
     // Matches the value inside a html title tag
-    private const TITLE_TAG_VALUE = '/<title[^>]*>(.*?)<\/title>/i';
+    private const string TITLE_TAG_VALUE = '/<title[^>]*>(.*?)<\/title>/i';
     // Matches the charset inside a Content-Type header
-    private const CHARSET_VALUE = '/charset=([^;]+)/i';
+    private const string CHARSET_VALUE = '/charset=([^;]+)/i';
 
     public function __construct(
         private ClientInterface $httpClient,

--- a/module/Core/src/ShortUrl/Middleware/TrimTrailingSlashMiddleware.php
+++ b/module/Core/src/ShortUrl/Middleware/TrimTrailingSlashMiddleware.php
@@ -14,7 +14,7 @@ use function rtrim;
 
 class TrimTrailingSlashMiddleware implements MiddlewareInterface
 {
-    private const SHORT_CODE_ATTR = 'shortCode';
+    private const string SHORT_CODE_ATTR = 'shortCode';
 
     public function __construct(private readonly UrlShortenerOptions $options)
     {

--- a/module/Core/src/ShortUrl/Model/Validation/CustomSlugValidator.php
+++ b/module/Core/src/ShortUrl/Model/Validation/CustomSlugValidator.php
@@ -12,8 +12,8 @@ use function strpbrk;
 
 class CustomSlugValidator extends AbstractValidator
 {
-    private const NOT_STRING = 'NOT_STRING';
-    private const CONTAINS_URL_CHARACTERS = 'CONTAINS_URL_CHARACTERS';
+    private const string NOT_STRING = 'NOT_STRING';
+    private const string CONTAINS_URL_CHARACTERS = 'CONTAINS_URL_CHARACTERS';
 
     protected array $messageTemplates = [
         self::NOT_STRING => 'Provided value is not a string.',

--- a/module/Core/src/ShortUrl/Model/Validation/ShortUrlInputFilter.php
+++ b/module/Core/src/ShortUrl/Model/Validation/ShortUrlInputFilter.php
@@ -24,22 +24,22 @@ use const Shlinkio\Shlink\MIN_SHORT_CODES_LENGTH;
 class ShortUrlInputFilter extends InputFilter
 {
     // Fields for creation only
-    public const SHORT_CODE_LENGTH = 'shortCodeLength';
-    public const CUSTOM_SLUG = 'customSlug';
-    public const PATH_PREFIX = 'pathPrefix';
-    public const FIND_IF_EXISTS = 'findIfExists';
-    public const DOMAIN = 'domain';
+    public const string SHORT_CODE_LENGTH = 'shortCodeLength';
+    public const string CUSTOM_SLUG = 'customSlug';
+    public const string PATH_PREFIX = 'pathPrefix';
+    public const string FIND_IF_EXISTS = 'findIfExists';
+    public const string DOMAIN = 'domain';
 
     // Fields for creation and edition
-    public const LONG_URL = 'longUrl';
-    public const VALID_SINCE = 'validSince';
-    public const VALID_UNTIL = 'validUntil';
-    public const MAX_VISITS = 'maxVisits';
-    public const TITLE = 'title';
-    public const TAGS = 'tags';
-    public const CRAWLABLE = 'crawlable';
-    public const FORWARD_QUERY = 'forwardQuery';
-    public const API_KEY = 'apiKey';
+    public const string LONG_URL = 'longUrl';
+    public const string VALID_SINCE = 'validSince';
+    public const string VALID_UNTIL = 'validUntil';
+    public const string MAX_VISITS = 'maxVisits';
+    public const string TITLE = 'title';
+    public const string TAGS = 'tags';
+    public const string CRAWLABLE = 'crawlable';
+    public const string FORWARD_QUERY = 'forwardQuery';
+    public const string API_KEY = 'apiKey';
 
     public static function forCreation(array $data, UrlShortenerOptions $options): self
     {

--- a/module/Core/src/ShortUrl/Model/Validation/ShortUrlsParamsInputFilter.php
+++ b/module/Core/src/ShortUrl/Model/Validation/ShortUrlsParamsInputFilter.php
@@ -16,17 +16,17 @@ use function Shlinkio\Shlink\Core\enumValues;
 /** @extends InputFilter<mixed> */
 class ShortUrlsParamsInputFilter extends InputFilter
 {
-    public const PAGE = 'page';
-    public const SEARCH_TERM = 'searchTerm';
-    public const TAGS = 'tags';
-    public const START_DATE = 'startDate';
-    public const END_DATE = 'endDate';
-    public const ITEMS_PER_PAGE = 'itemsPerPage';
-    public const TAGS_MODE = 'tagsMode';
-    public const ORDER_BY = 'orderBy';
-    public const EXCLUDE_MAX_VISITS_REACHED = 'excludeMaxVisitsReached';
-    public const EXCLUDE_PAST_VALID_UNTIL = 'excludePastValidUntil';
-    public const DOMAIN = 'domain';
+    public const string PAGE = 'page';
+    public const string SEARCH_TERM = 'searchTerm';
+    public const string TAGS = 'tags';
+    public const string START_DATE = 'startDate';
+    public const string END_DATE = 'endDate';
+    public const string ITEMS_PER_PAGE = 'itemsPerPage';
+    public const string TAGS_MODE = 'tagsMode';
+    public const string ORDER_BY = 'orderBy';
+    public const string EXCLUDE_MAX_VISITS_REACHED = 'excludeMaxVisitsReached';
+    public const string EXCLUDE_PAST_VALID_UNTIL = 'excludePastValidUntil';
+    public const string DOMAIN = 'domain';
 
     public function __construct(array $data)
     {

--- a/module/Core/src/Visit/Model/Visitor.php
+++ b/module/Core/src/Visit/Model/Visitor.php
@@ -17,11 +17,11 @@ use const Shlinkio\Shlink\REDIRECT_URL_REQUEST_ATTRIBUTE;
 
 final readonly class Visitor
 {
-    public const USER_AGENT_MAX_LENGTH = 512;
-    public const REFERER_MAX_LENGTH = 1024;
-    public const REMOTE_ADDRESS_MAX_LENGTH = 256;
-    public const VISITED_URL_MAX_LENGTH = 2048;
-    public const REDIRECT_URL_MAX_LENGTH = 2048;
+    public const int USER_AGENT_MAX_LENGTH = 512;
+    public const int REFERER_MAX_LENGTH = 1024;
+    public const int REMOTE_ADDRESS_MAX_LENGTH = 256;
+    public const int VISITED_URL_MAX_LENGTH = 2048;
+    public const int REDIRECT_URL_MAX_LENGTH = 2048;
 
     private function __construct(
         public string $userAgent,

--- a/module/Core/src/Visit/Repository/VisitIterationRepositoryInterface.php
+++ b/module/Core/src/Visit/Repository/VisitIterationRepositoryInterface.php
@@ -9,7 +9,7 @@ use Shlinkio\Shlink\Core\Visit\Entity\Visit;
 
 interface VisitIterationRepositoryInterface
 {
-    public const DEFAULT_BLOCK_SIZE = 10000;
+    public const int DEFAULT_BLOCK_SIZE = 10000;
 
     /**
      * @return iterable<Visit>

--- a/module/Core/test/Action/QrCodeActionTest.php
+++ b/module/Core/test/Action/QrCodeActionTest.php
@@ -32,8 +32,8 @@ use const Shlinkio\Shlink\DEFAULT_QR_CODE_COLOR;
 
 class QrCodeActionTest extends TestCase
 {
-    private const WHITE = 0xFFFFFF;
-    private const BLACK = 0x0;
+    private const int WHITE = 0xFFFFFF;
+    private const int BLACK = 0x0;
 
     private MockObject & ShortUrlResolverInterface $urlResolver;
 

--- a/module/Core/test/Action/RedirectActionTest.php
+++ b/module/Core/test/Action/RedirectActionTest.php
@@ -23,7 +23,7 @@ use const Shlinkio\Shlink\REDIRECT_URL_REQUEST_ATTRIBUTE;
 
 class RedirectActionTest extends TestCase
 {
-    private const LONG_URL = 'https://domain.com/foo/bar?some=thing';
+    private const string LONG_URL = 'https://domain.com/foo/bar?some=thing';
 
     private RedirectAction $action;
     private MockObject & ShortUrlResolverInterface $urlResolver;

--- a/module/Core/test/ShortUrl/Helper/ShortUrlTitleResolutionHelperTest.php
+++ b/module/Core/test/ShortUrl/Helper/ShortUrlTitleResolutionHelperTest.php
@@ -22,7 +22,7 @@ use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlCreation;
 
 class ShortUrlTitleResolutionHelperTest extends TestCase
 {
-    private const LONG_URL = 'http://foobar.com/12345/hello?foo=bar';
+    private const string LONG_URL = 'http://foobar.com/12345/hello?foo=bar';
 
     private MockObject & ClientInterface $httpClient;
 

--- a/module/Core/test/Visit/RequestTrackerTest.php
+++ b/module/Core/test/Visit/RequestTrackerTest.php
@@ -23,7 +23,7 @@ use const Shlinkio\Shlink\IP_ADDRESS_REQUEST_ATTRIBUTE;
 
 class RequestTrackerTest extends TestCase
 {
-    private const LONG_URL = 'https://domain.com/foo/bar?some=thing';
+    private const string LONG_URL = 'https://domain.com/foo/bar?some=thing';
 
     private RequestTracker $requestTracker;
     private MockObject & VisitsTrackerInterface $visitsTracker;

--- a/module/Rest/src/Action/AbstractRestAction.php
+++ b/module/Rest/src/Action/AbstractRestAction.php
@@ -10,8 +10,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 abstract class AbstractRestAction implements RequestHandlerInterface, RequestMethodInterface, StatusCodeInterface
 {
-    protected const ROUTE_PATH = '';
-    protected const ROUTE_ALLOWED_METHODS = [];
+    protected const string ROUTE_PATH = '';
+    protected const array ROUTE_ALLOWED_METHODS = [];
 
     public static function getRouteDef(array $prevMiddleware = [], array $postMiddleware = []): array
     {

--- a/module/Rest/src/Action/Domain/DomainRedirectsAction.php
+++ b/module/Rest/src/Action/Domain/DomainRedirectsAction.php
@@ -14,10 +14,10 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class DomainRedirectsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/domains/redirects';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_PATCH];
+    protected const string ROUTE_PATH = '/domains/redirects';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_PATCH];
 
-    public function __construct(private DomainServiceInterface $domainService)
+    public function __construct(private readonly DomainServiceInterface $domainService)
     {
     }
 

--- a/module/Rest/src/Action/Domain/ListDomainsAction.php
+++ b/module/Rest/src/Action/Domain/ListDomainsAction.php
@@ -15,11 +15,13 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class ListDomainsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/domains';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/domains';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
-    public function __construct(private DomainServiceInterface $domainService, private NotFoundRedirectOptions $options)
-    {
+    public function __construct(
+        private readonly DomainServiceInterface $domainService,
+        private readonly NotFoundRedirectOptions $options,
+    ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface

--- a/module/Rest/src/Action/HealthAction.php
+++ b/module/Rest/src/Action/HealthAction.php
@@ -13,14 +13,14 @@ use Throwable;
 
 class HealthAction extends AbstractRestAction
 {
-    private const HEALTH_CONTENT_TYPE = 'application/health+json';
-    private const STATUS_PASS = 'pass';
-    private const STATUS_FAIL = 'fail';
+    private const string HEALTH_CONTENT_TYPE = 'application/health+json';
+    private const string STATUS_PASS = 'pass';
+    private const string STATUS_FAIL = 'fail';
 
-    public const ROUTE_PATH = '/health';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    public const string ROUTE_PATH = '/health';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
-    public function __construct(private EntityManagerInterface $em, private AppOptions $options)
+    public function __construct(private readonly EntityManagerInterface $em, private readonly AppOptions $options)
     {
     }
 

--- a/module/Rest/src/Action/MercureInfoAction.php
+++ b/module/Rest/src/Action/MercureInfoAction.php
@@ -15,11 +15,13 @@ use function sprintf;
 
 class MercureInfoAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/mercure-info';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/mercure-info';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
-    public function __construct(private JwtProviderInterface $jwtProvider, private array $mercureConfig)
-    {
+    public function __construct(
+        private readonly JwtProviderInterface $jwtProvider,
+        private readonly array $mercureConfig,
+    ) {
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface

--- a/module/Rest/src/Action/RedirectRule/ListRedirectRulesAction.php
+++ b/module/Rest/src/Action/RedirectRule/ListRedirectRulesAction.php
@@ -13,8 +13,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class ListRedirectRulesAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}/redirect-rules';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}/redirect-rules';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(
         private readonly ShortUrlResolverInterface $urlResolver,

--- a/module/Rest/src/Action/RedirectRule/SetRedirectRulesAction.php
+++ b/module/Rest/src/Action/RedirectRule/SetRedirectRulesAction.php
@@ -16,8 +16,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class SetRedirectRulesAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}/redirect-rules';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_POST, self::METHOD_PATCH];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}/redirect-rules';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_POST, self::METHOD_PATCH];
 
     public function __construct(
         private readonly ShortUrlResolverInterface $urlResolver,

--- a/module/Rest/src/Action/ShortUrl/CreateShortUrlAction.php
+++ b/module/Rest/src/Action/ShortUrl/CreateShortUrlAction.php
@@ -12,8 +12,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class CreateShortUrlAction extends AbstractCreateShortUrlAction
 {
-    protected const ROUTE_PATH = '/short-urls';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_POST];
+    protected const string ROUTE_PATH = '/short-urls';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_POST];
 
     /**
      * @throws ValidationException

--- a/module/Rest/src/Action/ShortUrl/DeleteShortUrlAction.php
+++ b/module/Rest/src/Action/ShortUrl/DeleteShortUrlAction.php
@@ -14,8 +14,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class DeleteShortUrlAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
 
     public function __construct(private DeleteShortUrlServiceInterface $deleteShortUrlService)
     {

--- a/module/Rest/src/Action/ShortUrl/DeleteShortUrlVisitsAction.php
+++ b/module/Rest/src/Action/ShortUrl/DeleteShortUrlVisitsAction.php
@@ -14,8 +14,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class DeleteShortUrlVisitsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}/visits';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}/visits';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
 
     public function __construct(private readonly ShortUrlVisitsDeleterInterface $deleter)
     {

--- a/module/Rest/src/Action/ShortUrl/EditShortUrlAction.php
+++ b/module/Rest/src/Action/ShortUrl/EditShortUrlAction.php
@@ -16,8 +16,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class EditShortUrlAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_PATCH];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_PATCH];
 
     public function __construct(
         private readonly ShortUrlServiceInterface $shortUrlService,

--- a/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
+++ b/module/Rest/src/Action/ShortUrl/ListShortUrlsAction.php
@@ -16,8 +16,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class ListShortUrlsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/short-urls';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(
         private readonly ShortUrlListServiceInterface $shortUrlService,

--- a/module/Rest/src/Action/ShortUrl/ResolveShortUrlAction.php
+++ b/module/Rest/src/Action/ShortUrl/ResolveShortUrlAction.php
@@ -15,8 +15,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class ResolveShortUrlAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(
         private readonly ShortUrlResolverInterface $urlResolver,

--- a/module/Rest/src/Action/ShortUrl/SingleStepCreateShortUrlAction.php
+++ b/module/Rest/src/Action/ShortUrl/SingleStepCreateShortUrlAction.php
@@ -11,8 +11,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class SingleStepCreateShortUrlAction extends AbstractCreateShortUrlAction
 {
-    protected const ROUTE_PATH = '/short-urls/shorten';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/short-urls/shorten';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     protected function buildShortUrlData(Request $request): ShortUrlCreation
     {

--- a/module/Rest/src/Action/Tag/DeleteTagsAction.php
+++ b/module/Rest/src/Action/Tag/DeleteTagsAction.php
@@ -13,10 +13,10 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class DeleteTagsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/tags';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
+    protected const string ROUTE_PATH = '/tags';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
 
-    public function __construct(private TagServiceInterface $tagService)
+    public function __construct(private readonly TagServiceInterface $tagService)
     {
     }
 

--- a/module/Rest/src/Action/Tag/ListTagsAction.php
+++ b/module/Rest/src/Action/Tag/ListTagsAction.php
@@ -15,8 +15,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class ListTagsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/tags';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/tags';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(private readonly TagServiceInterface $tagService)
     {

--- a/module/Rest/src/Action/Tag/TagsStatsAction.php
+++ b/module/Rest/src/Action/Tag/TagsStatsAction.php
@@ -15,8 +15,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class TagsStatsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/tags/stats';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/tags/stats';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(private readonly TagServiceInterface $tagService)
     {

--- a/module/Rest/src/Action/Tag/UpdateTagAction.php
+++ b/module/Rest/src/Action/Tag/UpdateTagAction.php
@@ -14,10 +14,10 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class UpdateTagAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/tags';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_PUT];
+    protected const string ROUTE_PATH = '/tags';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_PUT];
 
-    public function __construct(private TagServiceInterface $tagService)
+    public function __construct(private readonly TagServiceInterface $tagService)
     {
     }
 

--- a/module/Rest/src/Action/Visit/AbstractListVisitsAction.php
+++ b/module/Rest/src/Action/Visit/AbstractListVisitsAction.php
@@ -18,7 +18,7 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 abstract class AbstractListVisitsAction extends AbstractRestAction
 {
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
     public function __construct(protected readonly VisitsStatsHelperInterface $visitsHelper)
     {

--- a/module/Rest/src/Action/Visit/DeleteOrphanVisitsAction.php
+++ b/module/Rest/src/Action/Visit/DeleteOrphanVisitsAction.php
@@ -13,8 +13,8 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class DeleteOrphanVisitsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/visits/orphan';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
+    protected const string ROUTE_PATH = '/visits/orphan';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_DELETE];
 
     public function __construct(private readonly VisitsDeleterInterface $visitsDeleter)
     {

--- a/module/Rest/src/Action/Visit/DomainVisitsAction.php
+++ b/module/Rest/src/Action/Visit/DomainVisitsAction.php
@@ -14,7 +14,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
 class DomainVisitsAction extends AbstractListVisitsAction
 {
-    protected const ROUTE_PATH = '/domains/{domain}/visits';
+    protected const string ROUTE_PATH = '/domains/{domain}/visits';
 
     public function __construct(
         VisitsStatsHelperInterface $visitsHelper,

--- a/module/Rest/src/Action/Visit/GlobalVisitsAction.php
+++ b/module/Rest/src/Action/Visit/GlobalVisitsAction.php
@@ -13,10 +13,10 @@ use Shlinkio\Shlink\Rest\Middleware\AuthenticationMiddleware;
 
 class GlobalVisitsAction extends AbstractRestAction
 {
-    protected const ROUTE_PATH = '/visits';
-    protected const ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
+    protected const string ROUTE_PATH = '/visits';
+    protected const array ROUTE_ALLOWED_METHODS = [self::METHOD_GET];
 
-    public function __construct(private VisitsStatsHelperInterface $statsHelper)
+    public function __construct(private readonly VisitsStatsHelperInterface $statsHelper)
     {
     }
 

--- a/module/Rest/src/Action/Visit/NonOrphanVisitsAction.php
+++ b/module/Rest/src/Action/Visit/NonOrphanVisitsAction.php
@@ -11,7 +11,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
 class NonOrphanVisitsAction extends AbstractListVisitsAction
 {
-    protected const ROUTE_PATH = '/visits/non-orphan';
+    protected const string ROUTE_PATH = '/visits/non-orphan';
 
     protected function getVisitsPaginator(
         ServerRequestInterface $request,

--- a/module/Rest/src/Action/Visit/OrphanVisitsAction.php
+++ b/module/Rest/src/Action/Visit/OrphanVisitsAction.php
@@ -12,7 +12,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
 class OrphanVisitsAction extends AbstractListVisitsAction
 {
-    protected const ROUTE_PATH = '/visits/orphan';
+    protected const string ROUTE_PATH = '/visits/orphan';
 
     protected function getVisitsPaginator(
         ServerRequestInterface $request,

--- a/module/Rest/src/Action/Visit/ShortUrlVisitsAction.php
+++ b/module/Rest/src/Action/Visit/ShortUrlVisitsAction.php
@@ -12,7 +12,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
 class ShortUrlVisitsAction extends AbstractListVisitsAction
 {
-    protected const ROUTE_PATH = '/short-urls/{shortCode}/visits';
+    protected const string ROUTE_PATH = '/short-urls/{shortCode}/visits';
 
     protected function getVisitsPaginator(Request $request, VisitsParams $params, ApiKey $apiKey): Pagerfanta
     {

--- a/module/Rest/src/Action/Visit/TagVisitsAction.php
+++ b/module/Rest/src/Action/Visit/TagVisitsAction.php
@@ -11,7 +11,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
 class TagVisitsAction extends AbstractListVisitsAction
 {
-    protected const ROUTE_PATH = '/tags/{tag}/visits';
+    protected const string ROUTE_PATH = '/tags/{tag}/visits';
 
     protected function getVisitsPaginator(Request $request, VisitsParams $params, ApiKey $apiKey): Pagerfanta
     {

--- a/module/Rest/src/ConfigProvider.php
+++ b/module/Rest/src/ConfigProvider.php
@@ -12,9 +12,9 @@ use function sprintf;
 
 class ConfigProvider
 {
-    private const ROUTES_PREFIX = '/rest/v{version:1|2|3}';
-    private const UNVERSIONED_ROUTES_PREFIX = '/rest';
-    public const UNVERSIONED_HEALTH_ENDPOINT_NAME = 'unversioned_health';
+    private const string ROUTES_PREFIX = '/rest/v{version:1|2|3}';
+    private const string UNVERSIONED_ROUTES_PREFIX = '/rest';
+    public const string UNVERSIONED_HEALTH_ENDPOINT_NAME = 'unversioned_health';
 
     public function __invoke(): array
     {

--- a/module/Rest/src/Exception/MercureException.php
+++ b/module/Rest/src/Exception/MercureException.php
@@ -14,8 +14,8 @@ class MercureException extends RuntimeException implements ProblemDetailsExcepti
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Mercure integration not configured';
-    public const ERROR_CODE = 'mercure-not-configured';
+    private const string TITLE = 'Mercure integration not configured';
+    public const string ERROR_CODE = 'mercure-not-configured';
 
     public static function mercureNotConfigured(): self
     {

--- a/module/Rest/src/Exception/MissingAuthenticationException.php
+++ b/module/Rest/src/Exception/MissingAuthenticationException.php
@@ -16,8 +16,8 @@ class MissingAuthenticationException extends RuntimeException implements Problem
 {
     use CommonProblemDetailsExceptionTrait;
 
-    private const TITLE = 'Invalid authorization';
-    public const ERROR_CODE = 'missing-authentication';
+    private const string TITLE = 'Invalid authorization';
+    public const string ERROR_CODE = 'missing-authentication';
 
     public static function forHeaders(array $expectedHeaders): self
     {

--- a/module/Rest/src/Exception/VerifyAuthenticationException.php
+++ b/module/Rest/src/Exception/VerifyAuthenticationException.php
@@ -14,7 +14,7 @@ class VerifyAuthenticationException extends RuntimeException implements ProblemD
 {
     use CommonProblemDetailsExceptionTrait;
 
-    public const ERROR_CODE = 'invalid-api-key';
+    public const string ERROR_CODE = 'invalid-api-key';
 
     public static function forInvalidApiKey(): self
     {

--- a/module/Rest/src/Middleware/AuthenticationMiddleware.php
+++ b/module/Rest/src/Middleware/AuthenticationMiddleware.php
@@ -21,7 +21,7 @@ use function Shlinkio\Shlink\Core\ArrayUtils\contains;
 
 class AuthenticationMiddleware implements MiddlewareInterface, StatusCodeInterface, RequestMethodInterface
 {
-    public const API_KEY_HEADER = 'X-Api-Key';
+    public const string API_KEY_HEADER = 'X-Api-Key';
 
     public function __construct(
         private readonly ApiKeyServiceInterface $apiKeyService,

--- a/module/Rest/src/Middleware/ShortUrl/CreateShortUrlContentNegotiationMiddleware.php
+++ b/module/Rest/src/Middleware/ShortUrl/CreateShortUrlContentNegotiationMiddleware.php
@@ -18,8 +18,8 @@ use function strtolower;
 
 class CreateShortUrlContentNegotiationMiddleware implements MiddlewareInterface
 {
-    private const PLAIN_TEXT = 'text';
-    private const JSON = 'json';
+    private const string PLAIN_TEXT = 'text';
+    private const string JSON = 'json';
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/module/Rest/test-api/Action/ListRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/ListRedirectRulesTest.php
@@ -12,12 +12,12 @@ use function sprintf;
 
 class ListRedirectRulesTest extends ApiTestCase
 {
-    private const LANGUAGE_EN_CONDITION = [
+    private const array LANGUAGE_EN_CONDITION = [
         'type' => 'language',
         'matchKey' => null,
         'matchValue' => 'en',
     ];
-    private const QUERY_FOO_BAR_CONDITION = [
+    private const array QUERY_FOO_BAR_CONDITION = [
         'type' => 'query-param',
         'matchKey' => 'foo',
         'matchValue' => 'bar',

--- a/module/Rest/test-api/Action/ListShortUrlsTest.php
+++ b/module/Rest/test-api/Action/ListShortUrlsTest.php
@@ -15,7 +15,7 @@ use function count;
 
 class ListShortUrlsTest extends ApiTestCase
 {
-    private const SHORT_URL_SHLINK_WITH_TITLE = [
+    private const array SHORT_URL_SHLINK_WITH_TITLE = [
         'shortCode' => 'abc123',
         'shortUrl' => 'http://s.test/abc123',
         'longUrl' => 'https://shlink.io',
@@ -37,7 +37,7 @@ class ListShortUrlsTest extends ApiTestCase
         'forwardQuery' => true,
         'hasRedirectRules' => false,
     ];
-    private const SHORT_URL_DOCS = [
+    private const array SHORT_URL_DOCS = [
         'shortCode' => 'ghi789',
         'shortUrl' => 'http://s.test/ghi789',
         'longUrl' => 'https://shlink.io/documentation/',
@@ -59,7 +59,7 @@ class ListShortUrlsTest extends ApiTestCase
         'forwardQuery' => true,
         'hasRedirectRules' => false,
     ];
-    private const SHORT_URL_CUSTOM_SLUG_AND_DOMAIN = [
+    private const array SHORT_URL_CUSTOM_SLUG_AND_DOMAIN = [
         'shortCode' => 'custom-with-domain',
         'shortUrl' => 'http://some-domain.com/custom-with-domain',
         'longUrl' => 'https://google.com',
@@ -81,7 +81,7 @@ class ListShortUrlsTest extends ApiTestCase
         'forwardQuery' => true,
         'hasRedirectRules' => false,
     ];
-    private const SHORT_URL_META = [
+    private const array SHORT_URL_META = [
         'shortCode' => 'def456',
         'shortUrl' => 'http://s.test/def456',
         'longUrl' =>
@@ -105,7 +105,7 @@ class ListShortUrlsTest extends ApiTestCase
         'forwardQuery' => true,
         'hasRedirectRules' => true,
     ];
-    private const SHORT_URL_CUSTOM_SLUG = [
+    private const array SHORT_URL_CUSTOM_SLUG = [
         'shortCode' => 'custom',
         'shortUrl' => 'http://s.test/custom',
         'longUrl' => 'https://shlink.io',
@@ -127,7 +127,7 @@ class ListShortUrlsTest extends ApiTestCase
         'forwardQuery' => false,
         'hasRedirectRules' => false,
     ];
-    private const SHORT_URL_CUSTOM_DOMAIN = [
+    private const array SHORT_URL_CUSTOM_DOMAIN = [
         'shortCode' => 'ghi789',
         'shortUrl' => 'http://example.com/ghi789',
         'longUrl' =>

--- a/module/Rest/test-api/Action/OrphanVisitsTest.php
+++ b/module/Rest/test-api/Action/OrphanVisitsTest.php
@@ -13,7 +13,7 @@ use Shlinkio\Shlink\TestUtils\ApiTest\ApiTestCase;
 
 class OrphanVisitsTest extends ApiTestCase
 {
-    private const INVALID_SHORT_URL = [
+    private const array INVALID_SHORT_URL = [
         'referer' => 'https://s.test/foo',
         'date' => '2020-03-01T00:00:00+00:00',
         'userAgent' => 'cf-facebook',
@@ -23,7 +23,7 @@ class OrphanVisitsTest extends ApiTestCase
         'type' => 'invalid_short_url',
         'redirectUrl' => null,
     ];
-    private const REGULAR_NOT_FOUND = [
+    private const array REGULAR_NOT_FOUND = [
         'referer' => 'https://s.test/foo/bar',
         'date' => '2020-02-01T00:00:00+00:00',
         'userAgent' => 'shlink-tests-agent',
@@ -33,7 +33,7 @@ class OrphanVisitsTest extends ApiTestCase
         'type' => 'regular_404',
         'redirectUrl' => null,
     ];
-    private const BASE_URL = [
+    private const array BASE_URL = [
         'referer' => 'https://s.test',
         'date' => '2020-01-01T00:00:00+00:00',
         'userAgent' => 'shlink-tests-agent',

--- a/module/Rest/test-api/Action/SetRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/SetRedirectRulesTest.php
@@ -13,12 +13,12 @@ use function sprintf;
 
 class SetRedirectRulesTest extends ApiTestCase
 {
-    private const LANGUAGE_EN_CONDITION = [
+    private const array LANGUAGE_EN_CONDITION = [
         'type' => 'language',
         'matchKey' => null,
         'matchValue' => 'en',
     ];
-    private const QUERY_FOO_BAR_CONDITION = [
+    private const array QUERY_FOO_BAR_CONDITION = [
         'type' => 'query-param',
         'matchKey' => 'foo',
         'matchValue' => 'bar',


### PR DESCRIPTION
Closes #2247 

Bump required PHP version to `^8.3`, remove PHP 8.2 from pipelines, and add types to constants, which requires PHP 8.3