### PR TITLE
Be less restrictive on what characters are disallowed in custom slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
     This option effectively replaces the old `REDIRECT_APPEND_EXTRA_PATH` option, which is now deprecated and will be removed in Shlink 5.0.0
 
+* [#2156](https://github.com/shlinkio/shlink/issues/2156) Be less restrictive on what characters are disallowed in custom slugs.
+
+    All [URI-reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) were disallowed up until now, but from now on, only the gen-delimiters are.
+
 ### Changed
 * [#2281](https://github.com/shlinkio/shlink/issues/2281) Update docker image to PHP 8.4
 * [#2124](https://github.com/shlinkio/shlink/issues/2124) Improve how Shlink decides if a GeoLite db file needs to be downloaded, and reduces the chances for API limits to be reached.

--- a/module/Core/src/ShortUrl/Model/Validation/CustomSlugValidator.php
+++ b/module/Core/src/ShortUrl/Model/Validation/CustomSlugValidator.php
@@ -46,10 +46,10 @@ class CustomSlugValidator extends AbstractValidator
             return false;
         }
 
-        // URL reserved characters: https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
-        $reservedChars = "!*'();:@&=+$,?%#[]";
+        // URL gen-delimiter reserved characters, except `/`: https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
+        $reservedChars = ':?#[]@';
         if (! $this->options->multiSegmentSlugsEnabled) {
-            // Slashes should be allowed for multi-segment slugs
+            // Slashes should only be allowed if multi-segment slugs are enabled
             $reservedChars .= '/';
         }
 

--- a/module/Core/test/ShortUrl/Model/Validation/CustomSlugValidatorTest.php
+++ b/module/Core/test/ShortUrl/Model/Validation/CustomSlugValidatorTest.php
@@ -59,13 +59,11 @@ class CustomSlugValidatorTest extends TestCase
 
     public static function provideInvalidValues(): iterable
     {
+        yield ['port:8080'];
         yield ['foo?bar=baz'];
         yield ['some-thing#foo'];
-        yield ['call()'];
-        yield ['array[]'];
+        yield ['brackets[]'];
         yield ['email@example.com'];
-        yield ['wildcard*'];
-        yield ['$500'];
     }
 
     public function createValidator(bool $multiSegmentSlugsEnabled = false): CustomSlugValidator


### PR DESCRIPTION
Closes #2156 

Reduce the strictness on what characters can be used in custom slugs.

At one point, a bug was reported that using `?` would create invalid URLs, as the server would then detect anything after the question mark as part of the query string, and never match the short URL.

In order to prevent this, Shlink started to forbid the use of URL-reserved characters in custom slugs, but that broke the experience for users which were using some of those characters.

This PR reduces a bit the strictness, by still forbidding the use of URL-reserved characters that are used to split parts of a URI (gen-delimiters), but allowing other reserved characters (sub-delimiters) like `+` or `&`. 