### PR TITLE
Allow QR code logo to be individually disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
     All [URI-reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) were disallowed up until now, but from now on, only the gen-delimiters are.
 
+* [#2229](https://github.com/shlinkio/shlink/issues/2229) Add `logo=disabled` query param to dynamically disable the default logo on QR codes.
+
 ### Changed
 * [#2281](https://github.com/shlinkio/shlink/issues/2281) Update docker image to PHP 8.4
 * [#2124](https://github.com/shlinkio/shlink/issues/2124) Improve how Shlink decides if a GeoLite db file needs to be downloaded, and reduces the chances for API limits to be reached.

--- a/docs/swagger/paths/{shortCode}_qr-code.json
+++ b/docs/swagger/paths/{shortCode}_qr-code.json
@@ -85,6 +85,16 @@
                     "type": "string",
                     "default": "#ffffff"
                 }
+            },
+            {
+                "name": "logo",
+                "in": "query",
+                "description": "Currently used to disable the logo that was set via configuration options. It may be used in future to dynamically choose from multiple logos.",
+                "required": false,
+                "schema": {
+                    "type": "string",
+                    "enum": ["disable"]
+                }
             }
         ],
         "responses": {

--- a/module/Core/src/Action/Model/QrCodeParams.php
+++ b/module/Core/src/Action/Model/QrCodeParams.php
@@ -28,20 +28,21 @@ use function trim;
 use const Shlinkio\Shlink\DEFAULT_QR_CODE_BG_COLOR;
 use const Shlinkio\Shlink\DEFAULT_QR_CODE_COLOR;
 
-final class QrCodeParams
+final readonly class QrCodeParams
 {
     private const int MIN_SIZE = 50;
     private const int MAX_SIZE = 1000;
     private const array SUPPORTED_FORMATS = ['png', 'svg'];
 
     private function __construct(
-        public readonly int $size,
-        public readonly int $margin,
-        public readonly WriterInterface $writer,
-        public readonly ErrorCorrectionLevel $errorCorrectionLevel,
-        public readonly RoundBlockSizeMode $roundBlockSizeMode,
-        public readonly ColorInterface $color,
-        public readonly ColorInterface $bgColor,
+        public int $size,
+        public int $margin,
+        public WriterInterface $writer,
+        public ErrorCorrectionLevel $errorCorrectionLevel,
+        public RoundBlockSizeMode $roundBlockSizeMode,
+        public ColorInterface $color,
+        public ColorInterface $bgColor,
+        public bool $disableLogo,
     ) {
     }
 
@@ -57,6 +58,7 @@ final class QrCodeParams
             roundBlockSizeMode: self::resolveRoundBlockSize($query, $defaults),
             color: self::resolveColor($query, $defaults),
             bgColor: self::resolveBackgroundColor($query, $defaults),
+            disableLogo: isset($query['logo']) && $query['logo'] === 'disable',
         );
     }
 

--- a/module/Core/src/Action/QrCodeAction.php
+++ b/module/Core/src/Action/QrCodeAction.php
@@ -60,7 +60,7 @@ readonly class QrCodeAction implements MiddlewareInterface
     private function buildQrCode(Builder $qrCodeBuilder, QrCodeParams $params): ResultInterface
     {
         $logoUrl = $this->options->logoUrl;
-        if ($logoUrl === null) {
+        if ($logoUrl === null || $params->disableLogo) {
             return $qrCodeBuilder->build();
         }
 


### PR DESCRIPTION
Closes #2229 

Add a new `logo` parameter to the QR code URL that can be used to disable the globally configured logo.

The param is `logo=disable` so that it can be used in future to, for example, dynamically select from multiple logos, but for now it only accepts the `disabled` value and is ignored if any other value is provided.