### PR TITLE
Configure RoadRunner log encoding as json

### DIFF
--- a/config/roadrunner/.rr.dev.yml
+++ b/config/roadrunner/.rr.dev.yml
@@ -30,6 +30,7 @@ jobs:
         prefetch: 10
 
 logs:
+  encoding: json
   mode: development
   channels:
     http:

--- a/config/roadrunner/.rr.yml
+++ b/config/roadrunner/.rr.yml
@@ -28,6 +28,7 @@ jobs:
         prefetch: 10
 
 logs:
+  encoding: json
   mode: production
   channels:
     http:


### PR DESCRIPTION
Closes #2323 

Shlink logs are already in json so this should unify all logs as json

[road runner docs](https://docs.roadrunner.dev/docs/logging-and-observability/logger)