### PR TITLE
Close connections after every async job that uses the db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * *Nothing*
 
 ### Fixed
-* *Nothing*
+* [#2341](https://github.com/shlinkio/shlink/issues/2341) Ensure all asynchronous jobs that interact with the database do not leave idle connections open.
 
 
 # [4.4.0] - 2024-12-27

--- a/module/Core/config/event_dispatcher.config.php
+++ b/module/Core/config/event_dispatcher.config.php
@@ -73,6 +73,9 @@ return (static function (): array {
             ],
 
             'delegators' => [
+                EventDispatcher\Matomo\SendVisitToMatomo::class => [
+                    EventDispatcher\CloseDbConnectionEventListenerDelegator::class,
+                ],
                 EventDispatcher\Mercure\NotifyVisitToMercure::class => [
                     EventDispatcher\CloseDbConnectionEventListenerDelegator::class,
                 ],
@@ -92,6 +95,9 @@ return (static function (): array {
                     EventDispatcher\CloseDbConnectionEventListenerDelegator::class,
                 ],
                 EventDispatcher\LocateUnlocatedVisits::class => [
+                    EventDispatcher\CloseDbConnectionEventListenerDelegator::class,
+                ],
+                EventDispatcher\UpdateGeoLiteDb::class => [
                     EventDispatcher\CloseDbConnectionEventListenerDelegator::class,
                 ],
             ],

--- a/module/Core/src/EventDispatcher/CloseDbConnectionEventListener.php
+++ b/module/Core/src/EventDispatcher/CloseDbConnectionEventListener.php
@@ -11,7 +11,7 @@ class CloseDbConnectionEventListener
     /** @var callable */
     private $wrapped;
 
-    public function __construct(private ReopeningEntityManagerInterface $em, callable $wrapped)
+    public function __construct(private readonly ReopeningEntityManagerInterface $em, callable $wrapped)
     {
         $this->wrapped = $wrapped;
     }


### PR DESCRIPTION
Closes #2341

Decorate `UpdateGeoLiteDb` and `SendVisitToMatomo` with the `CloseDbConnectionEventListener`.

That ensures any database connection opened for them is closed afterwards, which is specially important for the geolite one, as it runs for every single visit.

This job didn't use to interact with the database before Shlink 4.4, so it was intentionally not decorated.

`SendVisitToMatomo` has always interacted with the database, it was just overlooked, but anyone not using this feature would not notice it.