### PR TITLE
Fix error when creating short URL for page with unsupported encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Fixed
 * [#2341](https://github.com/shlinkio/shlink/issues/2341) Ensure all asynchronous jobs that interact with the database do not leave idle connections open.
+* [#2334](https://github.com/shlinkio/shlink/issues/2334) Improve how page titles are encoded to UTF-8, falling back from mbstring to iconv if available, and ultimately using the original title in case of error, but never causing the short URL creation to fail.
 
 
 # [4.4.0] - 2024-12-27

--- a/module/Core/config/dependencies.config.php
+++ b/module/Core/config/dependencies.config.php
@@ -227,6 +227,7 @@ return [
         ShortUrl\Helper\ShortUrlTitleResolutionHelper::class => [
             'httpClient',
             Config\Options\UrlShortenerOptions::class,
+            'Logger_Shlink',
         ],
         ShortUrl\Helper\ShortUrlRedirectionBuilder::class => [
             Config\Options\TrackingOptions::class,


### PR DESCRIPTION
Closes #2334 

When a short URL is created, if title auto-resolution is enabled, there's some logic to convert the title into UTF-8. This logic could fail if the page's encoding is not supported by `mb_convert_encoding`.

This PR changes that so that we try to encode the title with `mb_convert_encoding`, then fall back to `iconv` if the extension is installed, and ultimately use the title as is if encoding was not possible.

In any case, we ensure the short URL creation does not fail if encoding the page title errors out.