### PR TITLE
Get back docker image building for ARM architecture

### DIFF
--- a/.github/workflows/ci-docker-image-build.yml
+++ b/.github/workflows/ci-docker-image-build.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   build-docker-image:
     uses: shlinkio/github-actions/.github/workflows/docker-image-build-ci.yml@main
+    with:
+      platforms: 'linux/arm64/v8,linux/amd64'

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         include:
           - runtime: 'rr'
-            platforms: 'linux/amd64' # TODO Build on linux/arm64/v8 again. For some reason it is failing
+            platforms: 'linux/arm64/v8,linux/amd64'
           - runtime: 'rr'
             tag-suffix: 'roadrunner'
-            platforms: 'linux/amd64' # TODO Build on linux/arm64/v8 again. For some reason it is failing
+            platforms: 'linux/arm64/v8,linux/amd64'
     uses: shlinkio/github-actions/.github/workflows/docker-publish-image.yml@main
     secrets: inherit
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2346](https://github.com/shlinkio/shlink/issues/2346) Get back docker images for ARM architectures.
+
+
 ## [4.4.1] - 2025-01-28
 ### Added
 * [#2331](https://github.com/shlinkio/shlink/issues/2331) Add `ADDRESS` env var which allows to customize the IP address to which RoadRunner binds, when using the official docker image.


### PR DESCRIPTION
Closes #2346

Enable docker image building for ARM architectures