### PR TITLE
Reproduce incorrect IP address with multiple reverse proxies

### DIFF
--- a/config/autoload/ip-address.global.php
+++ b/config/autoload/ip-address.global.php
@@ -15,6 +15,7 @@ return [
             'attribute_name' => IP_ADDRESS_REQUEST_ATTRIBUTE,
             'check_proxy_headers' => true,
             'trusted_proxies' => [],
+//            'trusted_proxies' => ['172.20.16.15', '172.20.16.17', '172.20.16.18'],
             'headers_to_inspect' => [
                 'CF-Connecting-IP',
                 'X-Forwarded-For',

--- a/data/infra/shlink_proxy_one.conf
+++ b/data/infra/shlink_proxy_one.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+
+    location / {
+        proxy_pass http://shlink_roadrunner:8080;
+        proxy_read_timeout 90s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/data/infra/shlink_proxy_three.conf
+++ b/data/infra/shlink_proxy_three.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+
+    location / {
+        proxy_pass http://shlink_proxy_two;
+        proxy_read_timeout 90s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/data/infra/shlink_proxy_two.conf
+++ b/data/infra/shlink_proxy_two.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+
+    location / {
+        proxy_pass http://shlink_proxy_one;
+        proxy_read_timeout 90s;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     shlink_nginx:
         container_name: shlink_nginx
-        image: nginx:1.25-alpine
+        image: nginx:1.27-alpine
         ports:
             - "8000:80"
         volumes:
@@ -65,6 +65,42 @@ services:
             LC_ALL: C
         extra_hosts:
             - 'host.docker.internal:host-gateway'
+
+    shlink_proxy_one:
+        container_name: shlink_proxy_one
+        image: nginx:1.27-alpine
+        ports:
+            - "8801:80"
+        volumes:
+            - ./data/infra/shlink_proxy_one.conf:/etc/nginx/conf.d/default.conf
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        links:
+            - shlink_roadrunner
+
+    shlink_proxy_two:
+        container_name: shlink_proxy_two
+        image: nginx:1.27-alpine
+        ports:
+            - "8802:80"
+        volumes:
+            - ./data/infra/shlink_proxy_two.conf:/etc/nginx/conf.d/default.conf
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        links:
+            - shlink_proxy_one
+
+    shlink_proxy_three:
+        container_name: shlink_proxy_three
+        image: nginx:1.27-alpine
+        ports:
+            - "8803:80"
+        volumes:
+            - ./data/infra/shlink_proxy_three.conf:/etc/nginx/conf.d/default.conf
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        links:
+            - shlink_proxy_two
 
     shlink_db_mysql:
         container_name: shlink_db_mysql
@@ -133,7 +169,7 @@ services:
 
     shlink_mercure_proxy:
         container_name: shlink_mercure_proxy
-        image: nginx:1.25-alpine
+        image: nginx:1.27-alpine
         ports:
             - "8002:80"
         volumes:


### PR DESCRIPTION
This is a reproduction of https://github.com/shlinkio/shlink/issues/2351, where the incorrect visitor IP address is resolved when Shlink is served behind a chain of two or more reverse proxies.

In here, three reverse proxies are configured in front of Shlink, with the next IP addresses:

* visitor - 172.20.16.1
* shlink_proxy_three - 172.20.16.18
* shlink_proxy_two - 172.20.16.17
* shlink_proxy_one - 172.20.16.15
* shlink - _not relevant_

I tried to visit every proxy, and see what IP addresses were resolved and set in every relevant header, and these are the results:

### akrabat/ip-address-middleware ^2.5

shlink (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.1
    X-Real-IP: -
    X-Forwarded-For: - 

shlink_proxy_one (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.1
    X-Forwarded-For: 172.20.16.1

shlink_proxy_two (trusted_proxies: [])

    Resolved IP: 172.20.16.17 (wrong 🔴)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.17

shlink_proxy_three (trusted_proxies: [])

    Resolved IP: 172.20.16.17 (wrong 🔴)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.18, 172.20.16.17


shlink_proxy_one (trusted_proxies: ['172.20.16.15'])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.1
    X-Forwarded-For: 172.20.16.1

shlink_proxy_two (trusted_proxies: ['172.20.16.15', '172.20.16.17'])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.17

shlink_proxy_three (trusted_proxies: ['172.20.16.15', '172.20.16.17', '172.20.16.18'])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.18, 172.20.16.17

### akrabat/ip-address-middleware 2.4.0

shlink (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.1
    X-Real-IP: -
    X-Forwarded-For: - 

shlink_proxy_one (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.1
    X-Forwarded-For: 172.20.16.1

shlink_proxy_two (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.17

shlink_proxy_three (trusted_proxies: [])

    Resolved IP: 172.20.16.1 (right 🟢)
    REMOTE_ADDR: 172.20.16.15
    X-Real-IP: 172.20.16.17
    X-Forwarded-For: 172.20.16.1, 172.20.16.18, 172.20.16.17

### Conclusion

`akrabat/ip-address-middleware: ^2.5` introduced a regression in order to fix a potential security issue. This is unfortunate, but there was probably not backwards-compatible way to solve it.

The result is that, while before, the first IP from the left was picked from `X-Forwarded-For`, now the first IP from the right which is not a trusted proxy is picked instead, so now it's required to set trusted proxies to retain the previous behavior.

Also, changing the order in which headers are checked to inspect `X-Real-IP` first would not solve the problem, as every proxy sets the IP of the previous one there, so we would still not resolve the visitor IP address when there's two or more proxies.