### PR TITLE
Downgrade symfony/lock to v7.2.0 to work around redis issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
   In the future, Shlink will allow you to define trusted proxies, to avoid other potential side effects because of this reversing of the list.
 
+* [#2354](https://github.com/shlinkio/shlink/issues/2354) Fix error "NOSCRIPT No matching script. Please use EVAL" thrown when creating a lock in redis.
+
 ## [4.4.2] - 2025-01-29
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "spiral/roadrunner-jobs": "^4.6",
         "symfony/console": "^7.2",
         "symfony/filesystem": "^7.2",
-        "symfony/lock": "^7.2",
+        "symfony/lock": "7.2.0",
         "symfony/process": "^7.2",
         "symfony/string": "^7.2"
     },


### PR DESCRIPTION
Closes #2354 

Temporarily pin `symfony/lock: 7.2.0` to work around an issue with redis.

The issue has already been fixed upstream, but a new version has not been released yet. I'll remove the workaround as soon as they release the fix.