### PR TITLE
Fix unique_short_code_plus_domain index in Microsoft SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [4.4.3] - 2025-02-15
 ### Added
 * *Nothing*
 
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
   In the future, Shlink will allow you to define trusted proxies, to avoid other potential side effects because of this reversing of the list.
 
 * [#2354](https://github.com/shlinkio/shlink/issues/2354) Fix error "NOSCRIPT No matching script. Please use EVAL" thrown when creating a lock in redis.
+* [#2319](https://github.com/shlinkio/shlink/issues/2319) Fix unique index for `short_code` and `domain_id` in `short_urls` table not being used in Microsoft SQL engines for rows where `domain_id` is `null`.
 
 ## [4.4.2] - 2025-01-29
 ### Added

--- a/module/Core/migrations/Version20250215100756.php
+++ b/module/Core/migrations/Version20250215100756.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkMigrations;
+
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Fix an incorrectly generated unique index in Microsoft SQL, on short_urls table, for short_code + domain_id columns.
+ * The index was generated only for rows where both columns were not null, which is not the desired behavior, as
+ * domain_id can be null.
+ * This is due to a bug in doctrine/dbal: https://github.com/doctrine/dbal/issues/3671
+ *
+ * FIXME DO NOT DELETE THIS MIGRATION! IT IS NOT POSSIBLE TO DO THIS IN ENTITY CONFIG CODE WHILE THE BUG EXISTS
+ */
+final class Version20250215100756 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(! $this->isMicrosoftSql());
+
+        // Drop the existing unique index
+        $shortUrls = $schema->getTable('short_urls');
+        $shortUrls->dropIndex('unique_short_code_plus_domain');
+    }
+
+    public function postUp(Schema $schema): void
+    {
+        // The only way to get the index properly generated is by hardcoding the SQL.
+        // Since this migration is run Microsoft SQL only, it is safe to use this approach.
+        $this->connection->executeStatement(
+            'CREATE UNIQUE INDEX unique_short_code_plus_domain ON short_urls (short_code, domain_id);',
+        );
+    }
+
+    private function isMicrosoftSql(): bool
+    {
+        return $this->connection->getDatabasePlatform() instanceof SQLServerPlatform;
+    }
+}


### PR DESCRIPTION
> Closes #2319

This PR is part of the investigation for https://github.com/shlinkio/shlink/issues/2319, and includes:

1. A simplification of the query used when finding one short URL with fallback from domain to non-domain one. Basically the query run when a short URL is visited.
    Now this query does not try to join with the `domains` table if provided domain is already `null`.
2. A fix for the `unique_short_code_plus_domain` index in Microsoft SQL, so that it also applies to rows where `domain_id` is null.