### PR TITLE
Downgrade to symfony/lock 7.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2366](https://github.com/shlinkio/shlink/issues/2366) Fix error "Cannot use 'SCRIPT' with redis-cluster" thrown when creating a lock while using a redis cluster.
+
 ## [4.4.3] - 2025-02-15
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "spiral/roadrunner-jobs": "^4.6",
         "symfony/console": "^7.2",
         "symfony/filesystem": "^7.2",
-        "symfony/lock": "7.2.0",
+        "symfony/lock": "7.1.6",
         "symfony/process": "^7.2",
         "symfony/string": "^7.2"
     },


### PR DESCRIPTION
Fixes #2366 

Downgrade to `symfony/lock` 7.1.6 to avoid a [regression](https://github.com/symfony/symfony/issues/59795) introduced in v7.2 when using a redis cluster.

Once fixed upstream this can point to the latest version again.