### PR TITLE
Disable reporting of deprecation warnings for prod env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2373](https://github.com/shlinkio/shlink/issues/2373) Ensure deprecation warnings do not end up escalated to `ErrorException`s by `ProblemDetailsMiddleware`.
+
+
 ## [4.4.4] - 2025-02-19
 ### Added
 * *Nothing*

--- a/config/roadrunner/.rr.dev.yml
+++ b/config/roadrunner/.rr.dev.yml
@@ -4,7 +4,7 @@ rpc:
   listen: tcp://127.0.0.1:6001
 
 server:
-  command: 'php ../../bin/roadrunner-worker.php'
+  command: 'php -derror_reporting="E_ALL" ../../bin/roadrunner-worker.php'
 
 http:
   address: '0.0.0.0:8080'

--- a/config/roadrunner/.rr.test.yml
+++ b/config/roadrunner/.rr.test.yml
@@ -9,7 +9,7 @@ rpc:
     listen: tcp://127.0.0.1:6001
 
 server:
-    command: 'php ./bin/roadrunner-worker.php'
+    command: 'php -derror_reporting="E_ALL" ./bin/roadrunner-worker.php'
 
 http:
     address: '0.0.0.0:9999'

--- a/config/roadrunner/.rr.yml
+++ b/config/roadrunner/.rr.yml
@@ -4,7 +4,7 @@ rpc:
   listen: tcp://127.0.0.1:6001
 
 server:
-  command: 'php -dopcache.enable_cli=1 -dopcache.validate_timestamps=0 ../../bin/roadrunner-worker.php'
+  command: 'php -dopcache.enable_cli=1 -dopcache.validate_timestamps=0 -derror_reporting="E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED" ../../bin/roadrunner-worker.php'
 
 http:
   address: '${ADDRESS:-0.0.0.0}:${PORT:-8080}'

--- a/data/infra/php.ini
+++ b/data/infra/php.ini
@@ -1,5 +1,4 @@
 display_errors=On
-error_reporting=-1
 log_errors_max_len=0
 zend.assertions=1
 assert.exception=1


### PR DESCRIPTION
Closes #2373

Enable error reporting for any kind of error in dev and test envs, but disable reporting of deprecation warnings in production.

This is needed because the `ProblemDetailsMiddleware` wraps the whole execution in an error handler which converts any reported error into an `ErrorException`. See https://github.com/mezzio/mezzio-problem-details/blob/68a17a0/src/ProblemDetailsMiddleware.php#L101-L118

It is good to know about deprecation warnings when in dev, as those need to be eventually fixed, but in production, they should not cause the whole request to fail.

#### Todo

- [ ] Verify this indeed fixes #2373, and allows short URLs with tags to be created when using redis with an encrypted connection.