### PR TITLE
Disable deprecation warnings when running in production envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2373](https://github.com/shlinkio/shlink/issues/2373) Ensure deprecation warnings do not end up escalated to `ErrorException`s by `ProblemDetailsMiddleware`.
+
+  In order to do this, Shlink will entirely ignore deprecation warnings when running in production, as those do not mean something is not working, but only that something will break in future versions.
+
+
 ## [4.4.4] - 2025-02-19
 ### Added
 * *Nothing*

--- a/config/container.php
+++ b/config/container.php
@@ -11,6 +11,7 @@ use function Shlinkio\Shlink\Core\enumValues;
 
 use const Shlinkio\Shlink\LOCAL_LOCK_FACTORY;
 
+// Set current directory to the project's root directory
 chdir(dirname(__DIR__));
 
 require 'vendor/autoload.php';
@@ -21,7 +22,11 @@ loadEnvVarsFromConfig(
     enumValues(EnvVars::class),
 );
 
-// This is one of the first files loaded. Configure the timezone and memory limit here
+// This is one of the first files loaded. Set global configuration here
+error_reporting(
+    // Set a less strict error reporting for prod, where deprecation warnings should be ignored
+    EnvVars::isProdEnv() ? E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED : E_ALL,
+);
 ini_set('memory_limit', EnvVars::MEMORY_LIMIT->loadFromEnv());
 date_default_timezone_set(EnvVars::TIMEZONE->loadFromEnv());
 

--- a/data/infra/php.ini
+++ b/data/infra/php.ini
@@ -1,5 +1,4 @@
 display_errors=On
-error_reporting=-1
 log_errors_max_len=0
 zend.assertions=1
 assert.exception=1


### PR DESCRIPTION
Closes #2373

Enable error reporting for any kind of error in dev and test envs, but disable reporting of deprecation warnings in production.

This is needed because the `ProblemDetailsMiddleware` wraps the whole execution in an error handler which converts any reported error into an `ErrorException`. See https://github.com/mezzio/mezzio-problem-details/blob/68a17a0/src/ProblemDetailsMiddleware.php#L101-L118

It is good to know about deprecation warnings when in dev, as those need to be eventually fixed, but in production, they should not cause the whole request to fail.

#### Todo

- [x] Verify this indeed fixes #2373, and allows short URLs with tags to be created when using redis with an encrypted connection.