### PR TITLE
Fix Matomo country logging by sending country code instead of country

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/migrations": "^3.8",
         "doctrine/orm": "^3.3",
         "donatj/phpuseragentparser": "^1.10",
-        "endroid/qr-code": "^6.0",
+        "endroid/qr-code": "<6.0.4",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "geoip2/geoip2": "^3.1",
         "guzzlehttp/guzzle": "^7.9",

--- a/module/Core/src/Matomo/MatomoVisitSender.php
+++ b/module/Core/src/Matomo/MatomoVisitSender.php
@@ -11,6 +11,8 @@ use Shlinkio\Shlink\Core\Visit\Entity\Visit;
 use Shlinkio\Shlink\Core\Visit\Repository\VisitIterationRepositoryInterface;
 use Throwable;
 
+use function strtolower;
+
 readonly class MatomoVisitSender implements MatomoVisitSenderInterface
 {
     public function __construct(

--- a/module/Core/src/Matomo/MatomoVisitSender.php
+++ b/module/Core/src/Matomo/MatomoVisitSender.php
@@ -60,7 +60,7 @@ readonly class MatomoVisitSender implements MatomoVisitSenderInterface
         if ($location !== null) {
             $tracker
                 ->setCity($location->cityName)
-                ->setCountry($location->countryName)
+                ->setCountry(strtolower($location->countryCode))
                 ->setLatitude($location->latitude)
                 ->setLongitude($location->longitude);
         }


### PR DESCRIPTION
Sending the country code is not enough, to display the country flag Matomo expects the code in lowercase. With only the code the flag in Matomo is still the question mark.
I hope it's okay to manipulate the capitalization at this location.
This fixes #2391 

From the Tracking API [documentation](https://developer.matomo.org/api-reference/tracking-api):

> country — An override value for the country. Should be set to the two letter country code of the visitor (lowercase), eg fr, de, us.

