### PR TITLE
Run tests under PHP 8.5 in CI

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -43,5 +43,5 @@ runs:
         coverage: xdebug
     - name: Install dependencies
       if: ${{ inputs.install-deps == 'yes' }}
-      run: composer install --no-interaction --prefer-dist
+      run: composer install --no-interaction --prefer-dist ${{ inputs.php-version == '8.5' && '--ignore-platform-req=php' || '' }}
       shell: bash

--- a/.github/workflows/ci-db-tests.yml
+++ b/.github/workflows/ci-db-tests.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.3', '8.4', '8.5']
+    continue-on-error: ${{ inputs.php-version == '8.5' }}
     env:
       LC_ALL: C
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,7 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.3', '8.4', '8.5']
+    continue-on-error: ${{ inputs.php-version == '8.5' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # rr get-binary picks this env automatically
     steps:


### PR DESCRIPTION
In preparation for PHP 8.5 release at the end of the year, run tests under PHP 8.5 beta, but allowing failures for now.