### PR TITLE
Make RedirectCondition->matchValue nullable

### DIFF
--- a/docs/swagger/definitions/SetShortUrlRedirectRule.json
+++ b/docs/swagger/definitions/SetShortUrlRedirectRule.json
@@ -31,7 +31,7 @@
             "type": ["string", "null"]
           },
           "matchValue":  {
-            "type": "string"
+            "type": ["string", "null"]
           }
         }
       }

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
@@ -39,5 +39,6 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
     fieldWithUtf8Charset($builder->createField('matchValue', Types::STRING), $emConfig)
         ->columnName('match_value')
         ->length(512)
+        ->nullable()
         ->build();
 };

--- a/module/Core/migrations/Version20250722060208.php
+++ b/module/Core/migrations/Version20250722060208.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ShlinkMigrations;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Make the redirect_condition match_value column nullable, so that we can support new valueless-query-param and
+ * any-value-query-param conditions consistently.
+ */
+final class Version20250722060208 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $schema->getTable('redirect_conditions')->getColumn('match_value')->setNotnull(false);
+    }
+
+    public function isTransactional(): bool
+    {
+        return ! ($this->connection->getDatabasePlatform() instanceof MySQLPlatform);
+    }
+}

--- a/module/Core/src/RedirectRule/Model/RedirectConditionType.php
+++ b/module/Core/src/RedirectRule/Model/RedirectConditionType.php
@@ -31,11 +31,7 @@ enum RedirectConditionType: string
             // RedirectConditionType::LANGUAGE => TODO Validate at least format,
             RedirectConditionType::IP_ADDRESS => IpAddressUtils::isStaticIpCidrOrWildcard($value),
             RedirectConditionType::GEOLOCATION_COUNTRY_CODE => contains($value, ISO_COUNTRY_CODES),
-            RedirectConditionType::QUERY_PARAM,
-            RedirectConditionType::ANY_VALUE_QUERY_PARAM,
-            RedirectConditionType::VALUELESS_QUERY_PARAM => $value !== '',
-            // FIXME We should at least validate the value is not empty
-            //  default => $value !== '',
+            RedirectConditionType::QUERY_PARAM => $value !== '',
             default => true,
         };
     }

--- a/module/Core/src/RedirectRule/Model/Validation/RedirectRulesInputFilter.php
+++ b/module/Core/src/RedirectRule/Model/Validation/RedirectRulesInputFilter.php
@@ -75,7 +75,7 @@ class RedirectRulesInputFilter extends InputFilter
         ]));
         $redirectConditionInputFilter->add($type);
 
-        $value = InputFactory::basic(self::CONDITION_MATCH_VALUE, required: true);
+        $value = InputFactory::basic(self::CONDITION_MATCH_VALUE, required: true)->setAllowEmpty(true);
         $value->getValidatorChain()->attach(new Callback(
             function (string $value, array $context): bool {
                 $conditionType = RedirectConditionType::tryFrom($context[self::CONDITION_TYPE]);

--- a/module/Core/test/RedirectRule/Model/RedirectConditionTypeTest.php
+++ b/module/Core/test/RedirectRule/Model/RedirectConditionTypeTest.php
@@ -14,9 +14,9 @@ class RedirectConditionTypeTest extends TestCase
     #[Test]
     #[TestWith([RedirectConditionType::QUERY_PARAM, '', false])]
     #[TestWith([RedirectConditionType::QUERY_PARAM, 'foo', true])]
-    #[TestWith([RedirectConditionType::ANY_VALUE_QUERY_PARAM, '', false])]
+    #[TestWith([RedirectConditionType::ANY_VALUE_QUERY_PARAM, '', true])]
     #[TestWith([RedirectConditionType::ANY_VALUE_QUERY_PARAM, 'foo', true])]
-    #[TestWith([RedirectConditionType::VALUELESS_QUERY_PARAM, '', false])]
+    #[TestWith([RedirectConditionType::VALUELESS_QUERY_PARAM, '', true])]
     #[TestWith([RedirectConditionType::VALUELESS_QUERY_PARAM, 'foo', true])]
     public function isValidFailsForEmptyQueryParams(
         RedirectConditionType $conditionType,

--- a/module/Rest/test-api/Action/ListRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/ListRedirectRulesTest.php
@@ -17,11 +17,6 @@ class ListRedirectRulesTest extends ApiTestCase
         'matchKey' => null,
         'matchValue' => 'en',
     ];
-    private const array QUERY_FOO_BAR_CONDITION = [
-        'type' => 'query-param',
-        'matchKey' => 'foo',
-        'matchValue' => 'bar',
-    ];
 
     #[Test]
     public function errorIsReturnedWhenInvalidUrlIsFetched(): void
@@ -45,7 +40,11 @@ class ListRedirectRulesTest extends ApiTestCase
             'priority' => 1,
             'conditions' => [
                 self::LANGUAGE_EN_CONDITION,
-                self::QUERY_FOO_BAR_CONDITION,
+                [
+                    'type' => 'any-value-query-param',
+                    'matchKey' => 'foo',
+                    'matchValue' => null,
+                ],
             ],
         ],
         [
@@ -57,7 +56,11 @@ class ListRedirectRulesTest extends ApiTestCase
                     'matchKey' => 'hello',
                     'matchValue' => 'world',
                 ],
-                self::QUERY_FOO_BAR_CONDITION,
+                [
+                    'type' => 'query-param',
+                    'matchKey' => 'foo',
+                    'matchValue' => 'bar',
+                ],
             ],
         ],
         [

--- a/module/Rest/test-api/Action/SetRedirectRulesTest.php
+++ b/module/Rest/test-api/Action/SetRedirectRulesTest.php
@@ -18,11 +18,6 @@ class SetRedirectRulesTest extends ApiTestCase
         'matchKey' => null,
         'matchValue' => 'en',
     ];
-    private const array QUERY_FOO_BAR_CONDITION = [
-        'type' => 'query-param',
-        'matchKey' => 'foo',
-        'matchValue' => 'bar',
-    ];
 
     #[Test]
     public function errorIsReturnedWhenInvalidUrlIsProvided(): void
@@ -132,7 +127,11 @@ class SetRedirectRulesTest extends ApiTestCase
             'priority' => 1,
             'conditions' => [
                 self::LANGUAGE_EN_CONDITION,
-                self::QUERY_FOO_BAR_CONDITION,
+                [
+                    'type' => 'any-value-query-param',
+                    'matchKey' => 'foo',
+                    'matchValue' => null,
+                ],
             ],
         ],
         [
@@ -144,7 +143,11 @@ class SetRedirectRulesTest extends ApiTestCase
                     'matchKey' => 'hello',
                     'matchValue' => 'world',
                 ],
-                self::QUERY_FOO_BAR_CONDITION,
+                [
+                    'type' => 'query-param',
+                    'matchKey' => 'foo',
+                    'matchValue' => 'bar',
+                ],
             ],
         ],
     ]])]

--- a/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlRedirectRulesFixture.php
@@ -41,7 +41,7 @@ class ShortUrlRedirectRulesFixture extends AbstractFixture implements DependentF
             priority: 1,
             longUrl: 'https://example.com/english-and-foo-query',
             conditions: new ArrayCollection(
-                [RedirectCondition::forLanguage('en'), RedirectCondition::forQueryParam('foo', 'bar')],
+                [RedirectCondition::forLanguage('en'), RedirectCondition::forAnyValueQueryParam('foo')],
             ),
         );
         $manager->persist($englishAndFooQueryRule);


### PR DESCRIPTION
Closes #2462 

This PR updates the `matchValue` property in `RedirectCondition` so that it can be null, allowing conditions where only the `matchKey` is defined.

This makes the new `any-value-query-param` and `valueless-query-param` conditions consistent with the already existing `query-param` one, where the query parameter name is defined in `matchKey`.

Since the two new conditions do not need to specify a value, the param name was originally defined in `matchValue`, but that can be confusing.

This changes introduce a slightly small breaking change in the API, where `matchValue` can now be null, but since that can only happen with new condition types introduced in this version, I think it's reasonable.