### PR TITLE
Update to symfony/lock ^7.3.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "spiral/roadrunner-jobs": "^4.6",
         "symfony/console": "^7.3",
         "symfony/filesystem": "^7.3",
-        "symfony/lock": "7.1.6",
+        "symfony/lock": "^7.3.2",
         "symfony/process": "^7.3",
         "symfony/string": "^7.3"
     },


### PR DESCRIPTION
Shlink was pinning to `symfony/lock` 7.1.6 due to [an issue](https://github.com/symfony/symfony/issues/59795) when using redis cluster as lock store.

Now that issue has been resolved and included in v7.3.2, so this PR updates the requirement to `^7.3.2`.