### PR TITLE
Try to mitigate memory leaks when using RoadRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.5.1] - 2025-08-24
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2433](https://github.com/shlinkio/shlink/issues/2433) Try to mitigate memory leaks by restarting job and http workers every 250 executions when using RoadRunner.
+
 
 ## [4.5.0] - 2025-07-24
 ### Added

--- a/config/roadrunner/.rr.yml
+++ b/config/roadrunner/.rr.yml
@@ -14,11 +14,13 @@ http:
     forbid: ['.php', '.htaccess']
   pool:
     num_workers: ${WEB_WORKER_NUM:-0}
+    max_jobs: 250 # Restart worker after processing this amount of requests to mitigate memory leaks
 
 jobs:
   timeout: 300 # 5 minutes
   pool:
     num_workers: ${TASK_WORKER_NUM:-0}
+    max_jobs: 250 # Restart worker after processing this amount of jobs to mitigate memory leaks
   consume: ['shlink']
   pipelines:
     shlink:


### PR DESCRIPTION
Part of #2433

This is an attempt at mitigating memory leaks when using RoadRunner by restarting http and job workers after they have processed 250 requests/jobs.

This is not the proper solution, which should involve where is memory leaking. However, the PHP ecosystem has traditionally not been careful enough about this, because PHP apps were bootstrapped from scratched on every request. With modern app servers like RoadRunners and FrankenPHP, this can be a problem when using worker mode.