### PR TITLE
Garbage collect after every request

### DIFF
--- a/.github/workflows/ci-db-tests.yml
+++ b/.github/workflows/ci-db-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.3', '8.4', '8.5']
-    continue-on-error: ${{ inputs.php-version == '8.5' }}
+    continue-on-error: ${{ matrix.php-version == '8.5' }}
     env:
       LC_ALL: C
     steps:

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.3', '8.4', '8.5']
-    continue-on-error: ${{ inputs.php-version == '8.5' }}
+    continue-on-error: ${{ matrix.php-version == '8.5' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # rr get-binary picks this env automatically
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [4.5.2] - 2025-08-27
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2433](https://github.com/shlinkio/shlink/issues/2433) Try to mitigate memory leaks allowing RoadRunner to garbage collect memory after every request and every job, by setting `GC_COLLECT_CYCLES=true`.
+
+
 ## [4.5.1] - 2025-08-24
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "shlinkio/doctrine-specification": "^2.2",
         "shlinkio/shlink-common": "^7.1",
         "shlinkio/shlink-config": "^4.0",
-        "shlinkio/shlink-event-dispatcher": "^4.2",
+        "shlinkio/shlink-event-dispatcher": "^4.3",
         "shlinkio/shlink-importer": "^5.6",
         "shlinkio/shlink-installer": "^9.6",
         "shlinkio/shlink-ip-geolocation": "^4.3",


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2433

Try to mitigate memory leaks by garbage collecting after every request or every job, if `GC_COLLECT_CYCLES` env var is `true`.

This is an undocumented capability for now, since it's not clear yet if it's going to make a difference. If things get better, this mechanism may be enabled by default, and the env var could be documented.