### PR TITLE
Make GeoLite db download memory efficient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "shlinkio/shlink-event-dispatcher": "^4.3",
         "shlinkio/shlink-importer": "^5.6",
         "shlinkio/shlink-installer": "^9.6",
-        "shlinkio/shlink-ip-geolocation": "^4.3",
+        "shlinkio/shlink-ip-geolocation": "^4.4",
         "shlinkio/shlink-json": "^1.2",
         "spiral/roadrunner": "^2025.1",
         "spiral/roadrunner-cli": "^2.7",

--- a/config/autoload/geolite2.global.php
+++ b/config/autoload/geolite2.global.php
@@ -8,7 +8,7 @@ return [
 
     'geolite2' => [
         'db_location' => __DIR__ . '/../../data/GeoLite2-City.mmdb',
-        'temp_dir' => __DIR__ . '/../../data',
+        'temp_dir' => __DIR__ . '/../../data/temp-geolite',
         'license_key' => EnvVars::GEOLITE_LICENSE_KEY->loadFromEnv(),
     ],
 

--- a/data/temp-geolite/.gitignore
+++ b/data/temp-geolite/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 cd /etc/shlink
 
 # Create data directories if they do not exist. This allows data dir to be mounted as an empty dir if needed
-mkdir -p data/cache data/locks data/log data/proxies
+mkdir -p data/cache data/locks data/log data/proxies data/temp-geolite
 
 flags="--no-interaction --clear-db-cache"
 


### PR DESCRIPTION
[An issue](https://github.com/orgs/shlinkio/discussions/177) was reported some time ago, where the GeoLite db was not being downloaded.

Once the error traces and reproducible examples were shared, it was discovered the problem was that Shlink was [running out of memory](https://github.com/orgs/shlinkio/discussions/177#discussioncomment-14282379).

The GeoLite db download process ensured download happened in chunks, but the decompression process tried to load the whole file in memory, causing the crash if the amount of memory reserved for Shlink was lower than the file size.

In https://github.com/shlinkio/shlink-ip-geolocation/pull/73, the logic was improved, to decompress and read the file in chunks, to avoid too high memory consumption. Then that was released with `shlinkio/shlink-ip-geolocation` v4.4.0

This PR updates to that version and makes some minor configuration adjustments to take advantage of the new logic.