### PR TITLE
Make sure Access-Control-Allow-Credentials is always set if configured

### DIFF
--- a/module/Core/src/Config/Options/CorsOptions.php
+++ b/module/Core/src/Config/Options/CorsOptions.php
@@ -37,7 +37,19 @@ final readonly class CorsOptions
         );
     }
 
-    public function responseWithAllowOrigin(RequestInterface $request, ResponseInterface $response): ResponseInterface
+    /**
+     * Creates a new response which contains the CORS headers that apply to provided request
+     */
+    public function responseWithCorsHeaders(RequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $response = $this->responseWithAllowOrigin($request, $response);
+        return $this->allowCredentials ? $response->withHeader('Access-Control-Allow-Credentials', 'true') : $response;
+    }
+
+    /**
+     * If applicable, a new response with the appropriate Access-Control-Allow-Origin header is returned
+     */
+    private function responseWithAllowOrigin(RequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         if ($this->allowOrigins === '*') {
             return $response->withHeader('Access-Control-Allow-Origin', '*');

--- a/module/Rest/src/Middleware/CrossDomainMiddleware.php
+++ b/module/Rest/src/Middleware/CrossDomainMiddleware.php
@@ -28,7 +28,7 @@ readonly class CrossDomainMiddleware implements MiddlewareInterface, RequestMeth
         }
 
         // Add Allow-Origin header
-        $response = $this->options->responseWithAllowOrigin($request, $response);
+        $response = $this->options->responseWithCorsHeaders($request, $response);
         if ($request->getMethod() !== self::METHOD_OPTIONS) {
             return $response;
         }
@@ -38,18 +38,13 @@ readonly class CrossDomainMiddleware implements MiddlewareInterface, RequestMeth
 
     private function addOptionsHeaders(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $corsHeaders = [
+        // Options requests should always be empty and have a 204 status code
+        return EmptyResponse::withHeaders([
+            ...$response->getHeaders(),
             'Access-Control-Allow-Methods' => $this->resolveCorsAllowedMethods($response),
             'Access-Control-Allow-Headers' => $request->getHeaderLine('Access-Control-Request-Headers'),
             'Access-Control-Max-Age' => $this->options->maxAge,
-        ];
-
-        if ($this->options->allowCredentials) {
-            $corsHeaders['Access-Control-Allow-Credentials'] = 'true';
-        }
-
-        // Options requests should always be empty and have a 204 status code
-        return EmptyResponse::withHeaders([...$response->getHeaders(), ...$corsHeaders]);
+        ]);
     }
 
     private function resolveCorsAllowedMethods(ResponseInterface $response): string

--- a/module/Rest/test-api/Middleware/CorsTest.php
+++ b/module/Rest/test-api/Middleware/CorsTest.php
@@ -21,6 +21,7 @@ class CorsTest extends ApiTestCase
         self::assertFalse($resp->hasHeader('Access-Control-Allow-Methods'));
         self::assertFalse($resp->hasHeader('Access-Control-Max-Age'));
         self::assertFalse($resp->hasHeader('Access-Control-Allow-Headers'));
+        self::assertFalse($resp->hasHeader('Access-Control-Allow-Credentials'));
     }
 
     #[Test, DataProvider('provideOrigins')]
@@ -38,6 +39,7 @@ class CorsTest extends ApiTestCase
         self::assertFalse($resp->hasHeader('Access-Control-Allow-Methods'));
         self::assertFalse($resp->hasHeader('Access-Control-Max-Age'));
         self::assertFalse($resp->hasHeader('Access-Control-Allow-Headers'));
+        self::assertFalse($resp->hasHeader('Access-Control-Allow-Credentials'));
     }
 
     public static function provideOrigins(): iterable

--- a/module/Rest/test/Middleware/CrossDomainMiddlewareTest.php
+++ b/module/Rest/test/Middleware/CrossDomainMiddlewareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ShlinkioTest\Shlink\Rest\Middleware;
 
+use Fig\Http\Message\RequestMethodInterface;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -142,13 +143,17 @@ class CrossDomainMiddlewareTest extends TestCase
     }
 
     #[Test]
-    #[TestWith([true])]
-    #[TestWith([false])]
-    public function credentialsAreAllowedIfConfiguredSo(bool $allowCredentials): void
+    #[TestWith([true, RequestMethodInterface::METHOD_OPTIONS])]
+    #[TestWith([false, RequestMethodInterface::METHOD_OPTIONS])]
+    #[TestWith([true, RequestMethodInterface::METHOD_GET])]
+    #[TestWith([false, RequestMethodInterface::METHOD_GET])]
+    #[TestWith([true, RequestMethodInterface::METHOD_POST])]
+    #[TestWith([false, RequestMethodInterface::METHOD_POST])]
+    public function credentialsAreAllowedIfConfiguredSo(bool $allowCredentials, string $method): void
     {
         $originalResponse = new Response();
         $request = (new ServerRequest())
-            ->withMethod('OPTIONS')
+            ->withMethod($method)
             ->withHeader('Origin', 'local');
         $this->handler->method('handle')->willReturn($originalResponse);
 


### PR DESCRIPTION
Fixes https://github.com/shlinkio/shlink/issues/2488

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Credentials), the `Access-Control-Allow-Credentials` header should be set in all cross-origin responses, not only the ones for preflight requests. This PR makes sure that's the case when `CORS_ALLOW_ORIGIN` option is set to `true`.