### PR TITLE
Fix issue reported by phpstan in CrossDomainMiddleware

### DIFF
--- a/module/Rest/src/Middleware/CrossDomainMiddleware.php
+++ b/module/Rest/src/Middleware/CrossDomainMiddleware.php
@@ -39,12 +39,10 @@ readonly class CrossDomainMiddleware implements MiddlewareInterface, RequestMeth
     private function addOptionsHeaders(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         // Options requests should always be empty and have a 204 status code
-        return EmptyResponse::withHeaders([
-            ...$response->getHeaders(),
-            'Access-Control-Allow-Methods' => $this->resolveCorsAllowedMethods($response),
-            'Access-Control-Allow-Headers' => $request->getHeaderLine('Access-Control-Request-Headers'),
-            'Access-Control-Max-Age' => $this->options->maxAge,
-        ]);
+        return EmptyResponse::withHeaders($response->getHeaders())
+            ->withHeader('Access-Control-Allow-Methods', $this->resolveCorsAllowedMethods($response))
+            ->withHeader('Access-Control-Allow-Headers', $request->getHeaderLine('Access-Control-Request-Headers'))
+            ->withHeader('Access-Control-Max-Age', (string) $this->options->maxAge);
     }
 
     private function resolveCorsAllowedMethods(ResponseInterface $response): string


### PR DESCRIPTION
Due to a change in a recent version, PHPStan now reports an incorrect usage of `EmptyResponse::withHeaders`.

Things were working, probably due to internal checks accounting for headers set as `string` instead of `string[]`, but the type annotations were indicating the method was supposed to be used differently.

This PR refactors that slightly to ensure it is used as intended.