### PR TITLE
Extract tags option to its own Option class

### DIFF
--- a/module/CLI/src/Input/ShortUrlDataOption.php
+++ b/module/CLI/src/Input/ShortUrlDataOption.php
@@ -10,7 +10,6 @@ use function sprintf;
 
 enum ShortUrlDataOption: string
 {
-    case TAGS = 'tags';
     case VALID_SINCE = 'valid-since';
     case VALID_UNTIL = 'valid-until';
     case MAX_VISITS = 'max-visits';
@@ -21,7 +20,6 @@ enum ShortUrlDataOption: string
     public function shortcut(): string|null
     {
         return match ($this) {
-            self::TAGS => 't',
             self::VALID_SINCE => 's',
             self::VALID_UNTIL => 'u',
             self::MAX_VISITS => 'm',

--- a/module/CLI/src/Input/TagsOption.php
+++ b/module/CLI/src/Input/TagsOption.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\CLI\Input;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+
+use function array_map;
+use function array_unique;
+use function Shlinkio\Shlink\Core\ArrayUtils\flatten;
+use function Shlinkio\Shlink\Core\splitByComma;
+
+readonly class TagsOption
+{
+    public function __construct(Command $command, string $description)
+    {
+        $command
+            ->addOption(
+                'tag',
+                't',
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                $description,
+            )
+            ->addOption(
+                'tags',
+                mode: InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                description: '[DEPRECATED] Use --tag instead',
+            );
+    }
+
+    /**
+     * Whether tags have been set or not, via `--tag`, `-t` or the deprecated `--tags`
+     */
+    public function exists(InputInterface $input): bool
+    {
+        return $input->hasParameterOption(['--tag', '-t']) || $input->hasParameterOption('--tags');
+    }
+
+    /**
+     * @return string[]
+     */
+    public function get(InputInterface $input): array
+    {
+        // FIXME DEPRECATED Remove support for comma-separated tags in next major release
+        $tags = [...$input->getOption('tag'), ...$input->getOption('tags')];
+        return array_unique(flatten(array_map(splitByComma(...), $tags)));
+    }
+}


### PR DESCRIPTION
There are at least three commands which allow passing a list of tags. This PR extracts its logic to a reusable options class that all those commands can import.