### PR TITLE
Remove all calls to ReflectionProperty::setAccessible

### DIFF
--- a/module/CLI/test/Util/ShlinkTableTest.php
+++ b/module/CLI/test/Util/ShlinkTableTest.php
@@ -51,7 +51,6 @@ class ShlinkTableTest extends TestCase
 
         $ref = new ReflectionObject($instance);
         $baseTable = $ref->getProperty('baseTable');
-        $baseTable->setAccessible(true);
 
         self::assertInstanceOf(Table::class, $baseTable->getValue($instance));
     }

--- a/module/Core/test-db/ShortUrl/Repository/ShortUrlListRepositoryTest.php
+++ b/module/Core/test-db/ShortUrl/Repository/ShortUrlListRepositoryTest.php
@@ -85,7 +85,6 @@ class ShortUrlListRepositoryTest extends DatabaseTestCase
         $foo2->setVisits(new ArrayCollection($visits2));
         $ref = new ReflectionObject($foo2);
         $dateProp = $ref->getProperty('dateCreated');
-        $dateProp->setAccessible(true);
         $dateProp->setValue($foo2, Chronos::now()->subDays(5));
         $this->getEntityManager()->persist($foo2);
 

--- a/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
+++ b/module/Rest/test-api/Fixtures/ShortUrlsFixture.php
@@ -98,7 +98,6 @@ class ShortUrlsFixture extends AbstractFixture implements DependentFixtureInterf
     {
         $ref = new ReflectionObject($shortUrl);
         $dateProp = $ref->getProperty('dateCreated');
-        $dateProp->setAccessible(true);
         $dateProp->setValue($shortUrl, Chronos::parse($date));
 
         return $shortUrl;

--- a/module/Rest/test/Middleware/EmptyResponseImplicitOptionsMiddlewareFactoryTest.php
+++ b/module/Rest/test/Middleware/EmptyResponseImplicitOptionsMiddlewareFactoryTest.php
@@ -27,7 +27,6 @@ class EmptyResponseImplicitOptionsMiddlewareFactoryTest extends TestCase
 
         $ref = new ReflectionObject($instance);
         $prop = $ref->getProperty('responseFactory');
-        $prop->setAccessible(true);
 
         /** @var ResponseFactoryInterface $value */
         $value = $prop->getValue($instance);


### PR DESCRIPTION
Remove calls to ReflectionProperty::setAccessible, which is a noop since PHP 8.1, and is deprecated since PHP 8.5