### PR TITLE
Do not allow API keys to be disabled by plain-text key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * [#2507](https://github.com/shlinkio/shlink/issues/2507) Drop support for PHP 8.3.
 * [#2514](https://github.com/shlinkio/shlink/issues/2514) Remove support to generate QR codes. This functionality is now handled by Shlink Web Client and Shlink Dashboard.
 * [#2517](https://github.com/shlinkio/shlink/issues/2517) Remove `REDIRECT_APPEND_EXTRA_PATH` env var. Use `REDIRECT_EXTRA_PATH_MODE=append` instead.
+* [#2519](https://github.com/shlinkio/shlink/issues/2519) Disabling API keys by their plain-text key is no longer supported. When calling `api-key:disable`, the first argument is now always assumed to be the name.
 
 ### Fixed
 * *Nothing*

--- a/module/CLI/test/Command/Api/DisableKeyCommandTest.php
+++ b/module/CLI/test/Command/Api/DisableKeyCommandTest.php
@@ -31,12 +31,9 @@ class DisableKeyCommandTest extends TestCase
     public function providedApiKeyIsDisabled(): void
     {
         $apiKey = 'abcd1234';
-        $this->apiKeyService->expects($this->once())->method('disableByKey')->with($apiKey);
-        $this->apiKeyService->expects($this->never())->method('disableByName');
+        $this->apiKeyService->expects($this->once())->method('disableByName')->with($apiKey);
 
-        $exitCode = $this->commandTester->execute([
-            'key-or-name' => $apiKey,
-        ]);
+        $exitCode = $this->commandTester->execute(['name' => $apiKey]);
         $output = $this->commandTester->getDisplay();
 
         self::assertStringContainsString('API key "abcd1234" properly disabled', $output);
@@ -44,55 +41,15 @@ class DisableKeyCommandTest extends TestCase
     }
 
     #[Test]
-    public function providedApiKeyIsDisabledByName(): void
-    {
-        $name = 'the key to delete';
-        $this->apiKeyService->expects($this->once())->method('disableByName')->with($name);
-        $this->apiKeyService->expects($this->never())->method('disableByKey');
-
-        $exitCode = $this->commandTester->execute([
-            'key-or-name' => $name,
-            '--by-name' => true,
-        ]);
-        $output = $this->commandTester->getDisplay();
-
-        self::assertStringContainsString('API key "the key to delete" properly disabled', $output);
-        self::assertEquals(Command::SUCCESS, $exitCode);
-    }
-
-    #[Test]
-    public function errorIsReturnedIfDisableByKeyThrowsException(): void
+    public function errorIsReturnedIfDisableByNameThrowsException(): void
     {
         $apiKey = 'abcd1234';
         $expectedMessage = 'API key "abcd1234" does not exist.';
-        $this->apiKeyService->expects($this->once())->method('disableByKey')->with($apiKey)->willThrowException(
+        $this->apiKeyService->expects($this->once())->method('disableByName')->with($apiKey)->willThrowException(
             new InvalidArgumentException($expectedMessage),
         );
-        $this->apiKeyService->expects($this->never())->method('disableByName');
 
-        $exitCode = $this->commandTester->execute([
-            'key-or-name' => $apiKey,
-        ]);
-        $output = $this->commandTester->getDisplay();
-
-        self::assertStringContainsString($expectedMessage, $output);
-        self::assertEquals(Command::FAILURE, $exitCode);
-    }
-
-    #[Test]
-    public function errorIsReturnedIfDisableByNameThrowsException(): void
-    {
-        $name = 'the key to delete';
-        $expectedMessage = 'API key "the key to delete" does not exist.';
-        $this->apiKeyService->expects($this->once())->method('disableByName')->with($name)->willThrowException(
-            new InvalidArgumentException($expectedMessage),
-        );
-        $this->apiKeyService->expects($this->never())->method('disableByKey');
-
-        $exitCode = $this->commandTester->execute([
-            'key-or-name' => $name,
-            '--by-name' => true,
-        ]);
+        $exitCode = $this->commandTester->execute(['name' => $apiKey]);
         $output = $this->commandTester->getDisplay();
 
         self::assertStringContainsString($expectedMessage, $output);
@@ -103,7 +60,6 @@ class DisableKeyCommandTest extends TestCase
     public function warningIsReturnedIfNoArgumentIsProvidedInNonInteractiveMode(): void
     {
         $this->apiKeyService->expects($this->never())->method('disableByName');
-        $this->apiKeyService->expects($this->never())->method('disableByKey');
         $this->apiKeyService->expects($this->never())->method('listKeys');
 
         $exitCode = $this->commandTester->execute([], ['interactive' => false]);
@@ -121,7 +77,6 @@ class DisableKeyCommandTest extends TestCase
             ApiKey::fromMeta(ApiKeyMeta::fromParams(name: $name)),
             ApiKey::fromMeta(ApiKeyMeta::fromParams(name: 'bar')),
         ]);
-        $this->apiKeyService->expects($this->never())->method('disableByKey');
 
         $this->commandTester->setInputs([$name]);
         $exitCode = $this->commandTester->execute([]);

--- a/module/Rest/src/Service/ApiKeyService.php
+++ b/module/Rest/src/Service/ApiKeyService.php
@@ -92,19 +92,6 @@ readonly class ApiKeyService implements ApiKeyServiceInterface
         return $this->disableApiKey($apiKey);
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function disableByKey(string $key): ApiKey
-    {
-        $apiKey = $this->findByKey($key);
-        if ($apiKey === null) {
-            throw ApiKeyNotFoundException::forKey($key);
-        }
-
-        return $this->disableApiKey($apiKey);
-    }
-
     private function disableApiKey(ApiKey $apiKey): ApiKey
     {
         $apiKey->disable();

--- a/module/Rest/src/Service/ApiKeyServiceInterface.php
+++ b/module/Rest/src/Service/ApiKeyServiceInterface.php
@@ -33,12 +33,6 @@ interface ApiKeyServiceInterface
     public function disableByName(string $apiKeyName): ApiKey;
 
     /**
-     * @deprecated Use `self::disableByName($name)` instead
-     * @throws ApiKeyNotFoundException
-     */
-    public function disableByKey(string $key): ApiKey;
-
-    /**
      * @return ApiKey[]
      */
     public function listKeys(bool $enabledOnly = false): array;

--- a/module/Rest/test/Service/ApiKeyServiceTest.php
+++ b/module/Rest/test/Service/ApiKeyServiceTest.php
@@ -143,33 +143,27 @@ class ApiKeyServiceTest extends TestCase
         self::assertSame($apiKey, $result->apiKey);
     }
 
-    #[Test, DataProvider('provideDisableArgs')]
-    public function disableThrowsExceptionWhenNoApiKeyIsFound(string $disableMethod, array $findOneByArg): void
+    #[Test]
+    public function disableThrowsExceptionWhenNoApiKeyIsFound(): void
     {
-        $this->repo->expects($this->once())->method('findOneBy')->with($findOneByArg)->willReturn(null);
+        $this->repo->expects($this->once())->method('findOneBy')->with(['name' => '12345'])->willReturn(null);
 
         $this->expectException(ApiKeyNotFoundException::class);
 
-        $this->service->{$disableMethod}('12345');
+        $this->service->disableByName('12345');
     }
 
-    #[Test, DataProvider('provideDisableArgs')]
-    public function disableReturnsDisabledApiKeyWhenFound(string $disableMethod, array $findOneByArg): void
+    #[Test]
+    public function disableReturnsDisabledApiKeyWhenFound(): void
     {
         $key = ApiKey::create();
-        $this->repo->expects($this->once())->method('findOneBy')->with($findOneByArg)->willReturn($key);
+        $this->repo->expects($this->once())->method('findOneBy')->with(['name' => '12345'])->willReturn($key);
         $this->em->expects($this->once())->method('flush');
 
         self::assertTrue($key->isEnabled());
-        $returnedKey = $this->service->{$disableMethod}('12345');
+        $returnedKey = $this->service->disableByName('12345');
         self::assertFalse($key->isEnabled());
         self::assertSame($key, $returnedKey);
-    }
-
-    public static function provideDisableArgs(): iterable
-    {
-        yield 'disableByKey' => ['disableByKey', ['key' => ApiKey::hashKey('12345')]];
-        yield 'disableByName' => ['disableByName', ['name' => '12345']];
     }
 
     #[Test]


### PR DESCRIPTION
Closes https://github.com/shlinkio/shlink/issues/2519

Update the `api-key:disable` command so that the first argument is always assumed to be the API key name. This also removes the `--by-name` option.