### PR TITLE
Fix error when trying to persist non-utf-8 title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 * [#2565](https://github.com/shlinkio/shlink/issues/2565) Remove explicit dependency in ext-json, since it's part of PHP since v8.0
 
 ### Fixed
-* *Nothing*
+* [#2564](https://github.com/shlinkio/shlink/issues/2564) Fix error when trying to persist non-utf-8 title without being able to determine its original charset for parsing.
+
+  Now, when resolving a website's charset, two improvements have been introduced:
+
+  1. If the `Content-Type` header does not define the charset, we fall back to `<meta charset>` or `<meta http-equiv="Content-Type">`.
+  2. If it's still not possible to determine the charset, we ignore the auto-resolved title, to avoid other encoding errors further down the line.
 
 
 ## [4.6.0] - 2025-11-01


### PR DESCRIPTION
Closes #2564 

Improve charset parsing of auto-resolved titles so that:

1. If the Website's `Content-Type` header does not include the charset, we fall back to `<meta charset>` or `<meta http-equiv="Content-Type">` tags.
2. If it's still not possible to determine the charset, we ignore the auto-resolved title entirely, to avoid encoding errors when the value is persisted.

Up until now, we would try to persist an un-parsed title, which causes an error if it is not utf-8.