### PR TITLE
Update docker images to Alpine 3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [5.0.1] - 2026-03-04
 ### Added
 * *Nothing*
 
 ### Changed
 * [#2573](https://github.com/shlinkio/shlink/issues/2573) Update to PHPUnit 13
+* [#2579](https://github.com/shlinkio/shlink/issues/2579) Update docker images to Alpine 3.22, to address [CVE-2025-15467](https://nvd.nist.gov/vuln/detail/CVE-2025-15467)
 
 ### Deprecated
 * *Nothing*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-alpine3.21 AS base
+FROM php:8.4-alpine3.22 AS base
 
 ARG SHLINK_VERSION=latest
 ENV SHLINK_VERSION=${SHLINK_VERSION}

--- a/data/infra/php.Dockerfile
+++ b/data/infra/php.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm-alpine3.21
+FROM php:8.4-fpm-alpine3.22
 MAINTAINER Alejandro Celaya <alejandro@alejandrocelaya.com>
 
 ENV APCU_VERSION='5.1.24'

--- a/data/infra/roadrunner.Dockerfile
+++ b/data/infra/roadrunner.Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-alpine3.21
+FROM php:8.4-alpine3.22
 MAINTAINER Alejandro Celaya <alejandro@alejandrocelaya.com>
 
 ENV PDO_SQLSRV_VERSION='5.12.0'


### PR DESCRIPTION
Closes #2579

Update docker images to Alpine 3.22 to address [CVE-2025-15467](https://nvd.nist.gov/vuln/detail/CVE-2025-15467)