### PR TITLE
Add support for redis sentinels with their own ACL auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* [#2583](https://github.com/shlinkio/shlink/issues/2583) Support redis clusters with sentinels which have their own ACL authentication.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [5.0.1] - 2026-03-04
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "pagerfanta/core": "^3.8",
         "ramsey/uuid": "^4.7",
         "shlinkio/doctrine-specification": "^2.2",
-        "shlinkio/shlink-common": "^8.0.0",
+        "shlinkio/shlink-common": "^8.1.0",
         "shlinkio/shlink-config": "^4.1.0",
         "shlinkio/shlink-event-dispatcher": "^4.4.0",
         "shlinkio/shlink-importer": "^5.7.0",


### PR DESCRIPTION
Closes #2583 

Take advantage of  `predis/predis` 3.x (via https://github.com/shlinkio/shlink-common/pull/174), which allows ACL auth in sentinel servers.