### PR TITLE
Fix long URL edition via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.0.2] - 2026-04-16
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2593](https://github.com/shlinkio/shlink/issues/2593) Fix long URL being ignored when editing a short URL via `short-url:edit` console command.
+
+
 ## [5.0.1] - 2026-03-04
 ### Added
 * *Nothing*

--- a/module/CLI/src/Command/ShortUrl/EditShortUrlCommand.php
+++ b/module/CLI/src/Command/ShortUrl/EditShortUrlCommand.php
@@ -7,7 +7,6 @@ namespace Shlinkio\Shlink\CLI\Command\ShortUrl;
 use Shlinkio\Shlink\CLI\Command\ShortUrl\Input\ShortUrlDataInput;
 use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
 use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifierInterface;
-use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlEdition;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\ShortUrl\ShortUrlServiceInterface;
 use Symfony\Component\Console\Attribute\Argument;
@@ -46,7 +45,7 @@ class EditShortUrlCommand extends Command
         try {
             $shortUrl = $this->shortUrlService->updateShortUrl(
                 $identifier,
-                ShortUrlEdition::fromRawData($data->toArray()),
+                $data->toShortUrlEdition($longUrl),
             );
 
             $io->success(sprintf('Short URL "%s" properly edited', $this->stringifier->stringify($shortUrl)));

--- a/module/CLI/src/Command/ShortUrl/Input/ShortUrlDataInput.php
+++ b/module/CLI/src/Command/ShortUrl/Input/ShortUrlDataInput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\CLI\Command\ShortUrl\Input;
 
+use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlEdition;
 use Shlinkio\Shlink\Core\ShortUrl\Model\Validation\ShortUrlInputFilter;
 use Symfony\Component\Console\Attribute\Option;
 
@@ -76,5 +77,15 @@ final class ShortUrlDataInput
         }
 
         return $data;
+    }
+
+    public function toShortUrlEdition(string|null $longUrl): ShortUrlEdition
+    {
+        $data = $this->toArray();
+        if ($longUrl !== null) {
+            $data[ShortUrlInputFilter::LONG_URL] = $longUrl;
+        }
+
+        return ShortUrlEdition::fromRawData($data);
     }
 }

--- a/module/CLI/test-cli/Command/EditShortUrlTest.php
+++ b/module/CLI/test-cli/Command/EditShortUrlTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ShlinkioCliTest\Shlink\CLI\Command;
+
+use PHPUnit\Framework\Attributes\Test;
+use Shlinkio\Shlink\CLI\Command\ShortUrl\EditShortUrlCommand;
+use Shlinkio\Shlink\CLI\Command\ShortUrl\ResolveUrlCommand;
+use Shlinkio\Shlink\TestUtils\CliTest\CliTestCase;
+use Symfony\Component\Console\Command\Command;
+
+class EditShortUrlTest extends CliTestCase
+{
+    #[Test]
+    public function longUrlCanBeEdited(): void
+    {
+        [$originalOutput] = $this->exec([ResolveUrlCommand::NAME, 'abc123']);
+        self::assertStringContainsString('Long URL: https://shlink.io', $originalOutput);
+
+        [, $exitCode] = $this->exec([EditShortUrlCommand::NAME, 'abc123', '--long-url', 'https://example.com']);
+        self::assertEquals(Command::SUCCESS, $exitCode);
+
+        [$newOutput] = $this->exec([ResolveUrlCommand::NAME, 'abc123']);
+        self::assertStringContainsString('Long URL: https://example.com', $newOutput);
+    }
+}

--- a/module/CLI/test/Command/ShortUrl/EditShortUrlCommandTest.php
+++ b/module/CLI/test/Command/ShortUrl/EditShortUrlCommandTest.php
@@ -10,6 +10,7 @@ use Shlinkio\Shlink\CLI\Command\ShortUrl\EditShortUrlCommand;
 use Shlinkio\Shlink\Core\Exception\ShortUrlNotFoundException;
 use Shlinkio\Shlink\Core\ShortUrl\Entity\ShortUrl;
 use Shlinkio\Shlink\Core\ShortUrl\Helper\ShortUrlStringifierInterface;
+use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlEdition;
 use Shlinkio\Shlink\Core\ShortUrl\Model\ShortUrlIdentifier;
 use Shlinkio\Shlink\Core\ShortUrl\ShortUrlServiceInterface;
 use ShlinkioTest\Shlink\CLI\Util\CliTestUtils;
@@ -35,12 +36,16 @@ class EditShortUrlCommandTest extends TestCase
     #[Test]
     public function successMessageIsPrintedIfNoErrorOccurs(): void
     {
-        $this->shortUrlService->expects($this->once())->method('updateShortUrl')->willReturn(
+        $newLongUrl = 'https://example.com';
+        $this->shortUrlService->expects($this->once())->method('updateShortUrl')->with(
+            ShortUrlIdentifier::fromShortCodeAndDomain('foobar'),
+            $this->callback(static fn (ShortUrlEdition $edition): bool => $edition->longUrl === $newLongUrl),
+        )->willReturn(
             ShortUrl::createFake(),
         );
         $this->stringifier->expects($this->once())->method('stringify')->willReturn('https://s.test/foo');
 
-        $this->commandTester->execute(['short-code' => 'foobar']);
+        $this->commandTester->execute(['short-code' => 'foobar', '--long-url' => $newLongUrl]);
         $output = $this->commandTester->getDisplay();
         $exitCode = $this->commandTester->getStatusCode();
 


### PR DESCRIPTION
Closes #2593

After refactoring console commands to invokable commands, the short URL edition one dragged a regression where the long URL became ignored.

This PR fixes that ensuring it is taken into consideration again.