### PR TITLE
Remove the determineTableName function which has been a noop since forever

### DIFF
--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Domain.Entity.Domain.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('domains', $emConfig))
+    $builder->setTable('domains')
             ->setCustomRepositoryClass(Domain\Repository\DomainRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Geolocation.Entity.GeolocationDbUpdate.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Geolocation.Entity.GeolocationDbUpdate.php
@@ -14,7 +14,7 @@ use Shlinkio\Shlink\Core\Geolocation\Entity\GeolocationDbUpdateStatus;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('geolocation_db_updates', $emConfig));
+    $builder->setTable('geolocation_db_updates');
 
     $builder->createField('id', Types::BIGINT)
             ->columnName('id')

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.RedirectCondition.php
@@ -13,7 +13,7 @@ use Shlinkio\Shlink\Core\RedirectRule\Model\RedirectConditionType;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('redirect_conditions', $emConfig));
+    $builder->setTable('redirect_conditions');
 
     $builder->createField('id', Types::BIGINT)
             ->columnName('id')

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.RedirectRule.Entity.ShortUrlRedirectRule.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('short_url_redirect_rules', $emConfig));
+    $builder->setTable('short_url_redirect_rules');
 
     $builder->createField('id', Types::BIGINT)
             ->columnName('id')
@@ -36,7 +36,7 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
     // We treat this ManyToMany relation as a unidirectional OneToMany, where conditions are persisted and deleted
     // together with the rule
     $builder->createManyToMany('conditions', RedirectRule\Entity\RedirectCondition::class)
-            ->setJoinTable(determineTableName('redirect_conditions_in_short_url_redirect_rules', $emConfig))
+            ->setJoinTable('redirect_conditions_in_short_url_redirect_rules')
             ->addInverseJoinColumn('redirect_condition_id', 'id', onDelete: 'CASCADE')
             ->addJoinColumn('short_url_redirect_rule_id', 'id', onDelete: 'CASCADE')
             ->setOrderBy(['id' => 'ASC']) // Ensure a reliable order in the list of conditions

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.ShortUrl.Entity.ShortUrl.php
@@ -13,7 +13,7 @@ use Shlinkio\Shlink\Rest\Entity\ApiKey;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('short_urls', $emConfig))
+    $builder->setTable('short_urls')
             ->setCustomRepositoryClass(ShortUrl\Repository\ShortUrlRepository::class);
 
     $builder->createField('id', Types::BIGINT)
@@ -77,7 +77,7 @@ return static function (ClassMetadata $metadata, array $emConfig): void {
             ->build();
 
     $builder->createManyToMany('tags', Tag\Entity\Tag::class)
-            ->setJoinTable(determineTableName('short_urls_in_tags', $emConfig))
+            ->setJoinTable('short_urls_in_tags')
             ->addInverseJoinColumn('tag_id', 'id', onDelete: 'CASCADE')
             ->addJoinColumn('short_url_id', 'id', onDelete: 'CASCADE')
             ->setOrderBy(['name' => 'ASC'])

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Tag.Entity.Tag.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Tag.Entity.Tag.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('tags', $emConfig))
+    $builder->setTable('tags')
             ->setCustomRepositoryClass(Tag\Repository\TagRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.OrphanVisitsCount.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.OrphanVisitsCount.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('orphan_visits_counts', $emConfig))
+    $builder->setTable('orphan_visits_counts')
             ->setCustomRepositoryClass(Visit\Repository\OrphanVisitsCountRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.ShortUrlVisitsCount.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.ShortUrlVisitsCount.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('short_url_visits_counts', $emConfig))
+    $builder->setTable('short_url_visits_counts')
             ->setCustomRepositoryClass(Visit\Repository\ShortUrlVisitsCountRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.Visit.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.Visit.php
@@ -15,7 +15,7 @@ use Shlinkio\Shlink\Core\Visit\Model\VisitType;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('visits', $emConfig))
+    $builder->setTable('visits')
             ->setCustomRepositoryClass(Visit\Repository\VisitRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.VisitLocation.php
+++ b/module/Core/config/entities-mappings/Shlinkio.Shlink.Core.Visit.Entity.VisitLocation.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 return static function (ClassMetadata $metadata, array $emConfig): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('visit_locations', $emConfig));
+    $builder->setTable('visit_locations');
 
     $builder->createField('id', Types::BIGINT)
             ->columnName('id')

--- a/module/Core/functions/functions.php
+++ b/module/Core/functions/functions.php
@@ -207,18 +207,6 @@ function parseUserAgent(string $userAgent): UserAgent
     return $uaParser->parse($userAgent);
 }
 
-function determineTableName(string $tableName, array $emConfig = []): string
-{
-    $schema = $emConfig['connection']['schema'] ?? null;
-//    $tablePrefix = $emConfig['connection']['table_prefix'] ?? null; // TODO
-
-    if ($schema === null) {
-        return $tableName;
-    }
-
-    return sprintf('%s.%s', $schema, $tableName);
-}
-
 function fieldWithUtf8Charset(FieldBuilder $field, array $emConfig, string $collation = 'unicode_ci'): FieldBuilder
 {
     return match ($emConfig['connection']['driver'] ?? null) {

--- a/module/Rest/config/entities-mappings/Shlinkio.Shlink.Rest.Entity.ApiKey.php
+++ b/module/Rest/config/entities-mappings/Shlinkio.Shlink.Rest.Entity.ApiKey.php
@@ -10,12 +10,10 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Shlinkio\Shlink\Common\Doctrine\Type\ChronosDateTimeType;
 use Shlinkio\Shlink\Rest\Entity\ApiKeyRole;
 
-use function Shlinkio\Shlink\Core\determineTableName;
-
-return static function (ClassMetadata $metadata, array $emConfig): void {
+return static function (ClassMetadata $metadata): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('api_keys', $emConfig))
+    $builder->setTable('api_keys')
             ->setCustomRepositoryClass(ApiKey\Repository\ApiKeyRepository::class);
 
     $builder->createField('id', Types::BIGINT)

--- a/module/Rest/config/entities-mappings/Shlinkio.Shlink.Rest.Entity.ApiKeyRole.php
+++ b/module/Rest/config/entities-mappings/Shlinkio.Shlink.Rest.Entity.ApiKeyRole.php
@@ -11,12 +11,10 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Shlinkio\Shlink\Rest\ApiKey\Role;
 use Shlinkio\Shlink\Rest\Entity\ApiKey;
 
-use function Shlinkio\Shlink\Core\determineTableName;
-
-return static function (ClassMetadata $metadata, array $emConfig): void {
+return static function (ClassMetadata $metadata): void {
     $builder = new ClassMetadataBuilder($metadata);
 
-    $builder->setTable(determineTableName('api_key_roles', $emConfig));
+    $builder->setTable('api_key_roles');
 
     $builder->createField('id', Types::BIGINT)
             ->makePrimaryKey()


### PR DESCRIPTION
I intended to eventually add an option for this function to be useful, but it has been commented out for years and nobody seems to have missed it.