### PR TITLE
Remove setting of PDO::MYSQL_ATTR_SSL_KEY=true when DB encryption is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.1.3] - 2026-06-16
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2625](https://github.com/shlinkio/shlink/issues/2625) Fix `PDO::connect(): Unable to set local cert chain file 1` error when setting `DB_USE_ENCRYPTION=true` with MySQL and PHP 8.5.
+
+
 ## [5.1.2] - 2026-06-14
 ### Added
 * *Nothing*

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -36,7 +36,6 @@ return (static function (): array {
         'maria', 'mysql' => !$useEncryption
             ? []
             : [
-                1007 => true, // PDO::MYSQL_ATTR_SSL_KEY: Require using SSL
                 1014 => false, // PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: Trust any certificate
             ],
         'postgres' => !$useEncryption


### PR DESCRIPTION
Closes #2625

This PR removes the setting of `PDO::MYSQL_ATTR_SSL_KEY` with value `true`, when the driver is MySQL and database encryption is enabled.

This used to be a workaround to enforce SSL encrypted connections for database servers that support/require it, but the attribute itself is supposed to be used to set the path to a cert file.

In PHP 8.5, this is interpreted as `1` file path and fails, so this PR removes that attribute entirely.