### PR TITLE
Fix mysql tls encryption on PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [5.1.4] - 2026-06-18
 ### Added
 * *Nothing*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2625](https://github.com/shlinkio/shlink/issues/2625) Fix MySQL connections failing with `[3159] Connections using insecure transport are prohibited` when `DB_USE_ENCRYPTION=true` against a server requiring TLS.
+
+
 ## [5.1.3] - 2026-06-16
 ### Added
 * *Nothing*

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -36,8 +36,8 @@ return (static function (): array {
         'maria', 'mysql' => !$useEncryption
             ? []
             : [
-                Pdo\Mysql::ATTR_SSL_CA => '', // Require connections to be encrypted
-                Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false, // Allow any certificate
+                1008 => '', // Pdo\Mysql::ATTR_SSL_CA: Require connections to be encrypted
+                1013 => false, // Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT: Allow any certificate
             ],
         'postgres' => !$useEncryption
             ? []

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -36,7 +36,8 @@ return (static function (): array {
         'maria', 'mysql' => !$useEncryption
             ? []
             : [
-                1014 => false, // PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: Trust any certificate
+                Pdo\Mysql::ATTR_SSL_CA => '', // Require connections to be encrypted
+                Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false, // Allow any certificate
             ],
         'postgres' => !$useEncryption
             ? []

--- a/config/autoload/entity-manager.global.php
+++ b/config/autoload/entity-manager.global.php
@@ -33,12 +33,17 @@ return (static function (): array {
     };
     $driverOptions = match ($driver) {
         'mssql' => ['TrustServerCertificate' => 'true'],
-        'maria', 'mysql' => !$useEncryption
-            ? []
-            : [
-                1008 => '', // Pdo\Mysql::ATTR_SSL_CA: Require connections to be encrypted
-                1013 => false, // Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT: Allow any certificate
+        'maria', 'mysql' => match (true) {
+            !$useEncryption => [],
+            PHP_VERSION_ID < 80_500 => [
+                1007 => true, // PDO::MYSQL_ATTR_SSL_KEY: Require using SSL
+                1014 => false, // PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT: Trust any certificate
             ],
+            default => [
+                1008 => '', // Pdo\Mysql::ATTR_SSL_CA: Require connections to be encrypted
+                1013 => false, // Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT: Trust any certificate
+            ],
+        },
         'postgres' => !$useEncryption
             ? []
             : [


### PR DESCRIPTION
Closes #2625

This PR reverts the changes from https://github.com/shlinkio/shlink/pull/2626, as they are required when PHP 8.4 is used, and adds a different set of options for when PHP >=8.5 is used, as those changes did not fix the original issue for PHP 8.5.