### PR TITLE
 Fix migrations running when updating to Shlink 5.1.x while using Microsoft SQL database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.1.6] - 2026-09-06
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#2649](https://github.com/shlinkio/shlink/issues/2649) Fix migrations running when updating to Shlink 5.1.x while using Microsoft SQL database.
+
+
 ## [5.1.5] - 2026-06-22
 ### Added
 * *Nothing*

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "ext-pdo": "*",
         "akrabat/ip-address-middleware": "^2.6",
         "cakephp/chronos": "^3.5",
+        "cuyz/valinor": "~2.5.0",
         "doctrine/dbal": "^4.4",
         "doctrine/migrations": "^3.9",
         "doctrine/orm": "^3.6",

--- a/module/Core/migrations/Version20260524105410.php
+++ b/module/Core/migrations/Version20260524105410.php
@@ -26,7 +26,8 @@ final class Version20260524105410 extends AbstractMigration
 
         $shortUrls->addColumn(self::COLUMN_NAME, Types::BINARY, [
             'length' => 32,
-            'default' => '', // Temporary value until they have been filled by next migration
+            // Temporary default value until the column can be filled by the next migration
+            'default' => '0x',
         ]);
         $shortUrls->addIndex([self::COLUMN_NAME], self::INDEX_NAME);
     }

--- a/module/Core/migrations/Version20260524105410.php
+++ b/module/Core/migrations/Version20260524105410.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ShlinkMigrations;
 
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
@@ -24,12 +25,17 @@ final class Version20260524105410 extends AbstractMigration
             return;
         }
 
-        $shortUrls->addColumn(self::COLUMN_NAME, Types::BINARY, [
-            'length' => 32,
-            // Temporary default value until the column can be filled by the next migration
-            'default' => '0x',
-        ]);
-        $shortUrls->addIndex([self::COLUMN_NAME], self::INDEX_NAME);
+        if ($this->connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            $this->addSql('ALTER TABLE short_urls ADD ' . self::COLUMN_NAME . ' VARBINARY(32) NOT NULL DEFAULT (0x00)');
+            $this->addSql('CREATE INDEX ' . self::INDEX_NAME . ' ON short_urls(' . self::COLUMN_NAME . ')');
+        } else {
+            $shortUrls->addColumn(self::COLUMN_NAME, Types::BINARY, [
+                'length' => 32,
+                // Temporary default value until the column can be filled by the next migration
+                'default' => '',
+            ]);
+            $shortUrls->addIndex([self::COLUMN_NAME], self::INDEX_NAME);
+        }
     }
 
     public function down(Schema $schema): void

--- a/module/Core/migrations/Version20260607082210.php
+++ b/module/Core/migrations/Version20260607082210.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ShlinkMigrations;
 
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
@@ -18,26 +20,16 @@ final class Version20260607082210 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        $defaultHash = '0x';
+        $isMicrosoftSQL = $this->connection->getDatabasePlatform() instanceof SQLServerPlatform;
         do {
-            $resultsFound = $this->processBatch($defaultHash);
+            $resultsFound = $this->processBatch($isMicrosoftSQL);
         } while ($resultsFound);
     }
 
-    public function processBatch(string $defaultHash): bool
+    public function processBatch(bool $isMicrosoftSQL): bool
     {
-        $qb = $this->connection->createQueryBuilder();
-        $qb
-            ->select('id', 'original_url')
-            ->from('short_urls')
-            // If this migration times out, this will ensure it can be rerun, and it will continue where it was left, so
-            // it can be run multiple times until all short URLs have been processed
-            ->where($qb->expr()->eq('long_url_hash', ':longUrlHash'))
-            ->setParameters(['longUrlHash' => $defaultHash], ['longUrlHash' => Types::BINARY])
-            ->setMaxResults(10_000);
-        $shortUrlsResult = $qb->executeQuery();
-
-        return $this->connection->transactional(function () use ($shortUrlsResult) {
+        $shortUrlsResult = $this->executeFetchQuery($isMicrosoftSQL);
+        $callback = function () use ($shortUrlsResult) {
             $resultsFound = false;
 
             while ($row = $shortUrlsResult->fetchAssociative()) {
@@ -59,7 +51,35 @@ final class Version20260607082210 extends AbstractMigration
             }
 
             return $resultsFound;
-        });
+        };
+
+        // FIXME In MS SQL running this callback transactionally throws an exception, as if it was not honoring the
+        //       value of isTransactional()
+        return $isMicrosoftSQL ? $callback() : $this->connection->transactional($callback);
+    }
+
+    private function executeFetchQuery(bool $isMicrosoftSql): Result
+    {
+        if ($isMicrosoftSql) {
+            return $this->connection->executeQuery(
+                <<<SQL
+                    SELECT id, original_url FROM short_urls WHERE long_url_hash = 0x00
+                    ORDER BY (SELECT 0) OFFSET 0 ROWS FETCH NEXT 10000 ROWS ONLY
+                    SQL,
+            );
+        }
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('id', 'original_url')
+            ->from('short_urls')
+            // If this migration times out, this will ensure it can be rerun, and it will continue where it was left, so
+            // it can be run multiple times until all short URLs have been processed
+            ->where($qb->expr()->eq('long_url_hash', ':longUrlHash'))
+            ->setParameters(['longUrlHash' => ''], ['longUrlHash' => Types::BINARY])
+            ->setMaxResults(10_000);
+
+        return $qb->executeQuery();
     }
 
     public function isTransactional(): bool

--- a/module/Core/migrations/Version20260607082210.php
+++ b/module/Core/migrations/Version20260607082210.php
@@ -18,12 +18,13 @@ final class Version20260607082210 extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
+        $defaultHash = '0x';
         do {
-            $resultsFound = $this->processBatch();
+            $resultsFound = $this->processBatch($defaultHash);
         } while ($resultsFound);
     }
 
-    public function processBatch(): bool
+    public function processBatch(string $defaultHash): bool
     {
         $qb = $this->connection->createQueryBuilder();
         $qb
@@ -32,7 +33,7 @@ final class Version20260607082210 extends AbstractMigration
             // If this migration times out, this will ensure it can be rerun, and it will continue where it was left, so
             // it can be run multiple times until all short URLs have been processed
             ->where($qb->expr()->eq('long_url_hash', ':longUrlHash'))
-            ->setParameters(['longUrlHash' => ''])
+            ->setParameters(['longUrlHash' => $defaultHash], ['longUrlHash' => Types::BINARY])
             ->setMaxResults(10_000);
         $shortUrlsResult = $qb->executeQuery();
 


### PR DESCRIPTION
Closes #2649 

Update latest migrations (the ones related with the `long_url_hash` column) so that they run native queries when using MicrosoftSQL.

This is required because doctrine query builder cannot set a value that is interpreted as binary by MSSQL. It always ends up set as a string.