### PR TITLE
Update to doctrine/orm 3.7

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -43,5 +43,5 @@ runs:
         coverage: xdebug
     - name: Install dependencies
       if: ${{ inputs.install-deps == 'yes' }}
-      run: composer install --no-interaction --prefer-dist
+      run: composer install --no-interaction --prefer-dist ${{ inputs.php-version == '8.6' && '--ignore-platform-req=php' || '' }}
       shell: bash

--- a/.github/workflows/ci-db-tests.yml
+++ b/.github/workflows/ci-db-tests.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.4', '8.5']
+        php-version: ['8.4', '8.5', '8.6']
     env:
       LC_ALL: C
+    continue-on-error: ${{ matrix.php-version == '8.6' }}
     steps:
       - uses: actions/checkout@v5
       - name: Install MSSQL ODBC

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        php-version: ['8.4', '8.5']
+        php-version: ['8.4', '8.5', '8.6']
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # rr get-binary picks this env automatically
+    continue-on-error: ${{ matrix.php-version == '8.6' }}
     steps:
       - uses: actions/checkout@v5
       - name: Start postgres database server

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "cuyz/valinor": "~2.5.0",
         "doctrine/dbal": "^4.4",
         "doctrine/migrations": "^3.9",
-        "doctrine/orm": "^3.6",
+        "doctrine/orm": "^3.7",
         "donatj/phpuseragentparser": "^1.11",
         "friendsofphp/proxy-manager-lts": "^1.0",
         "geoip2/geoip2": "^3.3",

--- a/module/Core/src/ShortUrl/Entity/ShortUrl.php
+++ b/module/Core/src/ShortUrl/Entity/ShortUrl.php
@@ -8,6 +8,7 @@ use Cake\Chronos\Chronos;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Order;
 use Doctrine\Common\Collections\Selectable;
 use Shlinkio\Shlink\Common\Entity\AbstractEntity;
 use Shlinkio\Shlink\Core\Domain\Entity\Domain;
@@ -186,7 +187,7 @@ class ShortUrl extends AbstractEntity
     {
         $criteria = Criteria::create()
             ->where(Criteria::expr()->eq('type', VisitType::IMPORTED))
-            ->orderBy(['id' => 'DESC'])
+            ->orderBy(['id' => Order::Descending])
             ->setMaxResults(1);
         $visit = $this->visits->matching($criteria)->last();
 


### PR DESCRIPTION
Take the opportunity to also add PHP 8.6 to CI, but allowing to continue on failure for that version.